### PR TITLE
Init properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/roddone/YeelightAPI.svg?branch=master)](https://travis-ci.org/roddone/YeelightAPI)
+[![NuGet Package](https://img.shields.io/nuget/v/YeelightAPI.svg)](https://www.nuget.org/packages/YeelightAPI/)
 
 # YeelightAPI
 C# API (.Net) to control Xiaomi Yeelight Color Bulbs

--- a/YeelightAPI/Device.IDeviceReader.cs
+++ b/YeelightAPI/Device.IDeviceReader.cs
@@ -36,7 +36,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<Dictionary<PROPERTIES, object>> GetProps(PROPERTIES props)
         {
-            List<object> names = GetPropertiesRealNames(props);
+            List<object> names = props.GetRealNames();
 
             CommandResult commandResult = await ExecuteCommandWithResponse(
                 method: METHODS.GetProp,

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -1,14 +1,9 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using YeelightAPI.Models;
 
@@ -25,7 +20,7 @@ namespace YeelightAPI
         /// <summary>
         /// lock
         /// </summary>
-        private object _syncLock = new object();
+        private readonly object _syncLock = new object();
 
         /// <summary>
         /// TCP client used to communicate with the device
@@ -35,12 +30,12 @@ namespace YeelightAPI
         /// <summary>
         /// Dictionary of results
         /// </summary>
-        private Dictionary<object, object> _currentCommandResults = new Dictionary<object, object>();
+        private readonly Dictionary<object, object> _currentCommandResults = new Dictionary<object, object>();
 
         /// <summary>
         /// Serializer settings
         /// </summary>
-        private JsonSerializerSettings _serializerSettings = new JsonSerializerSettings()
+        private static readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings()
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };
@@ -80,12 +75,12 @@ namespace YeelightAPI
         /// <summary>
         /// HostName
         /// </summary>
-        public string Hostname { get; set; }
+        public string Hostname { get; }
 
         /// <summary>
         /// Port number
         /// </summary>
-        public int Port { get; set; }
+        public int Port { get; }
 
         #endregion PUBLIC PROPERTIES
 
@@ -123,7 +118,7 @@ namespace YeelightAPI
         /// <summary>
         /// List of device properties
         /// </summary>
-        public Dictionary<string, object> Properties = new Dictionary<string, object>();
+        public readonly Dictionary<string, object> Properties = new Dictionary<string, object>();
 
         /// <summary>
         /// Access property from its enum value
@@ -263,7 +258,7 @@ namespace YeelightAPI
                 Params = parameters ?? new List<object>()
             };
 
-            string data = JsonConvert.SerializeObject(command, this._serializerSettings);
+            string data = JsonConvert.SerializeObject(command, _serializerSettings);
             byte[] sentData = Encoding.ASCII.GetBytes(data + "\r\n"); // \r\n is the end of the message, it needs to be sent for the message to be read by the device
 
             lock (_syncLock)
@@ -305,7 +300,7 @@ namespace YeelightAPI
                                     //get every messages in the pipe
                                     foreach (string entry in datas.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries))
                                     {
-                                        CommandResult commandResult = JsonConvert.DeserializeObject<CommandResult>(entry, this._serializerSettings);
+                                        CommandResult commandResult = JsonConvert.DeserializeObject<CommandResult>(entry, _serializerSettings);
 
                                         if (commandResult != null && commandResult.Result != null)
                                         {
@@ -319,7 +314,7 @@ namespace YeelightAPI
                                         }
                                         else
                                         {
-                                            NotificationResult notificationResult = JsonConvert.DeserializeObject<NotificationResult>(entry, this._serializerSettings);
+                                            NotificationResult notificationResult = JsonConvert.DeserializeObject<NotificationResult>(entry, _serializerSettings);
 
                                             if (notificationResult != null && notificationResult.Method != null)
                                             {

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -87,11 +87,6 @@ namespace YeelightAPI
         /// </summary>
         public int Port { get; set; }
 
-        /// <summary>
-        /// Name of the device
-        /// </summary>
-        public string Name { get; set; }
-
         #endregion PUBLIC PROPERTIES
 
         #region CONSTRUCTOR
@@ -112,6 +107,13 @@ namespace YeelightAPI
             {
                 this.Connect().Wait();
             }
+        }
+
+        internal Device(string hostname, int port, Dictionary<string, object> properties)
+        {
+            this.Hostname = hostname;
+            this.Port = port;
+            this.Properties = properties;
         }
 
         #endregion CONSTRUCTOR
@@ -168,6 +170,18 @@ namespace YeelightAPI
             }
         }
 
+        public string Name
+        {
+            get
+            {
+                return this[PROPERTIES.name] as string;
+            }
+            set
+            {
+                this[PROPERTIES.name] = value;
+            }
+        }
+
         #endregion PROPERTIES ACCESS
 
         #region PUBLIC METHODS
@@ -192,7 +206,7 @@ namespace YeelightAPI
         /// <param name="parameters"></param>
         /// <param name="smooth"></param>
         /// <returns></returns>
-        public async Task<CommandResult<T>> ExecuteCommandWithResponse<T>(METHODS method, int id = 0, List<object> parameters = null) 
+        public async Task<CommandResult<T>> ExecuteCommandWithResponse<T>(METHODS method, int id = 0, List<object> parameters = null)
         {
             if (this._currentCommandResults.ContainsKey(id))
             {
@@ -334,22 +348,6 @@ namespace YeelightAPI
                     await Task.Delay(100);
                 }
             }, TaskCreationOptions.LongRunning);
-        }
-
-        /// <summary>
-        /// Get the real name of the properties
-        /// </summary>
-        /// <param name="properties"></param>
-        /// <returns></returns>
-        private static List<object> GetPropertiesRealNames(PROPERTIES properties)
-        {
-            var vals = Enum.GetValues(typeof(PROPERTIES));
-            return vals
-                         .Cast<PROPERTIES>()
-                         .Where(m => properties.HasFlag(m) && m != PROPERTIES.ALL && m != PROPERTIES.NONE)
-                         .Cast<PROPERTIES>()
-                         .Select(x => x.ToString())
-                         .ToList<object>();
         }
 
         /// <summary>

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -96,11 +96,11 @@ namespace YeelightAPI
         /// </summary>
         /// <param name="hostname"></param>
         /// <param name="port"></param>
-        public Device(string hostname, int port = Common.DefaultPort, string name = null, bool autoConnect = false)
+        /// <param name="autoConnect"></param>
+        public Device(string hostname, int port = Common.DefaultPort, bool autoConnect = false)
         {
             this.Hostname = hostname;
             this.Port = port;
-            this.Name = name;
 
             //autoconnect device if specified
             if (autoConnect)

--- a/YeelightAPI/Models/PropertiesExtensions.cs
+++ b/YeelightAPI/Models/PropertiesExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace YeelightAPI.Models
+{
+    internal static class PropertiesExtensions
+    {
+        /// <summary>
+        /// Get the real name of the properties
+        /// </summary>
+        /// <param name="properties"></param>
+        /// <returns></returns>
+        public static List<object> GetRealNames(this PROPERTIES properties)
+        {
+            var vals = Enum.GetValues(typeof(PROPERTIES));
+            return vals
+                .Cast<PROPERTIES>()
+                .Where(m => properties.HasFlag(m) && m != PROPERTIES.ALL && m != PROPERTIES.NONE)
+                .Select(x => x.ToString())
+                .ToList<object>();
+        }
+    }
+}

--- a/YeelightAPIConsoleTest/Program.cs
+++ b/YeelightAPIConsoleTest/Program.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using YeelightAPI;
 using YeelightAPI.Models;
@@ -103,8 +101,8 @@ namespace YeelightAPIConsoleTest
                         success &= await device.SetName("test");
                         WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
                         await Task.Delay(2000);
-                        
-                        Console.WriteLine("restoring name '' ...");
+
+                        Console.WriteLine("restoring name '{0}' ...", name);
                         success &= await device.SetName(name);
                         WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
                         await Task.Delay(2000);


### PR DESCRIPTION
First, thanks for your library. I've already started writing my own until I discovered your repository.

### About this PR:

The original code ignored all properties provided in the device's response to the discovery broadcast.

With this PR `DeviceLocator` parses all known properties from the response and initializes the `Device` object with this list. Therefore `DeviceLocator.GetDeviceInformationsFromSsdpMessage` now returns a fully constructed `Device` object.

Because this includes the device's name, I have changed `Device.Name` to a property around `Properties[PROPERTIES.name]` for convenience. Also, you cannot pass the device's name in the constructor anymore.

The discovery response contains additional properties like `id` and `model` (e.g. `mono` or `color`). However, those properties can't be added to `PROPERTIES` enum, because you cannot request them. They are only in the discovery response and the announcement message. Nevertheless, I think it would be helpful to add these properties to `Device` too. What do you think?

I've tried to follow your code styleguide. I tried hard not to remove `this.` at various places and to change `PROPERTIES` to pascal-case :wink: