### PR TITLE
CronGet used wrong API method

### DIFF
--- a/YeelightAPI/Device.IDeviceReader.cs
+++ b/YeelightAPI/Device.IDeviceReader.cs
@@ -23,8 +23,8 @@ namespace YeelightAPI
             List<object> parameters = new List<object>() { (int)type };
 
             CommandResult<CronResult> result = await ExecuteCommandWithResponse<CronResult>(
-                            method: METHODS.SetName,
-                            id: (int)METHODS.SetName,
+                            method: METHODS.GetCron,
+                            id: (int)METHODS.GetCron,
                             parameters: parameters);
 
             return result?.Result;


### PR DESCRIPTION
`Device.CronGet` used the wrong method name: it called `METHODS.SetName` instead of `METHODS.GetCron` (I guess a copy&paste error 😉)