### PR TITLE
[RFC] Use TaskCompletionSource to avoid polling

### DIFF
--- a/YeelightAPI/CommandResultHandler.cs
+++ b/YeelightAPI/CommandResultHandler.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using YeelightAPI.Models;
+
+namespace YeelightAPI
+{
+    internal interface ICommandResultHandler
+    {
+        Type ResultType { get; }
+
+        void SetResult(CommandResult commandResult);
+
+        void SetError(CommandResult.CommandErrorResult commandResultError);
+        void TrySetCanceled();
+    }
+
+    internal class CommandResultHandler<T> : ICommandResultHandler
+    {
+        private readonly TaskCompletionSource<CommandResult<T>> _tcs = new TaskCompletionSource<CommandResult<T>>();
+
+        public Type ResultType => typeof(CommandResult<T>);
+
+        public void SetResult(CommandResult commandResult)
+        {
+            _tcs.SetResult((CommandResult<T>)commandResult);
+        }
+
+        public void SetError(CommandResult.CommandErrorResult commandResultError)
+        {
+            _tcs.SetException(new Exception(commandResultError.ToString()));
+        }
+
+        public void TrySetCanceled()
+        {
+            _tcs.TrySetCanceled();
+        }
+
+        public Task<CommandResult<T>> Task => _tcs.Task;
+    }
+}

--- a/YeelightAPI/CommandResultHandler.cs
+++ b/YeelightAPI/CommandResultHandler.cs
@@ -1,40 +1,104 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using YeelightAPI.Models;
 
 namespace YeelightAPI
 {
+    /// <summary>
+    /// Handler interface for CommandResult
+    /// </summary>
     internal interface ICommandResultHandler
     {
+        /// <summary>
+        /// Type of the result
+        /// </summary>
         Type ResultType { get; }
 
+        /// <summary>
+        /// Sets the result
+        /// </summary>
+        /// <param name="commandResult"></param>
         void SetResult(CommandResult commandResult);
 
+        /// <summary>
+        /// Sets the error
+        /// </summary>
+        /// <param name="commandResultError"></param>
         void SetError(CommandResult.CommandErrorResult commandResultError);
+
+        /// <summary>
+        /// Try to cancel
+        /// </summary>
         void TrySetCanceled();
     }
 
+    /// <summary>
+    /// Handler for CommandResult
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     internal class CommandResultHandler<T> : ICommandResultHandler
     {
+        /// <summary>
+        /// Task Completion Source
+        /// </summary>
         private readonly TaskCompletionSource<CommandResult<T>> _tcs = new TaskCompletionSource<CommandResult<T>>();
 
+        /// <summary>
+        /// Cancellation Token Source
+        /// </summary>
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource(5000);
+
+        /// <summary>
+        /// Type of the result
+        /// </summary>
         public Type ResultType => typeof(CommandResult<T>);
 
+        /// <summary>
+        /// Task object
+        /// </summary>
+        public Task<CommandResult<T>> Task => _tcs.Task;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal CommandResultHandler()
+        {
+            //automatic cancel after 5 seconds
+            _cts.Token.Register(() =>
+            {
+                Console.WriteLine("Task cancelled (timeout)", ConsoleColor.DarkYellow);
+                TrySetCanceled();
+            });
+        }
+
+        /// <summary>
+        /// Sets the result
+        /// </summary>
+        /// <param name="commandResult"></param>
         public void SetResult(CommandResult commandResult)
         {
             _tcs.SetResult((CommandResult<T>)commandResult);
+            _cts?.Dispose();
         }
 
+        /// <summary>
+        /// Sets the error
+        /// </summary>
+        /// <param name="commandResultError"></param>
         public void SetError(CommandResult.CommandErrorResult commandResultError)
         {
             _tcs.SetException(new Exception(commandResultError.ToString()));
+            _cts?.Dispose();
         }
 
+        /// <summary>
+        /// Try to cancel
+        /// </summary>
         public void TrySetCanceled()
         {
             _tcs.TrySetCanceled();
+            _cts?.Dispose();
         }
-
-        public Task<CommandResult<T>> Task => _tcs.Task;
     }
 }

--- a/YeelightAPI/Device.IBackgroundDeviceController.cs
+++ b/YeelightAPI/Device.IBackgroundDeviceController.cs
@@ -24,7 +24,7 @@ namespace YeelightAPI
             {
                 List<object> parameters = new List<object>() { action.ToString(), property.ToString() };
 
-                CommandResult result = await ExecuteCommandWithResponse(
+                CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                     method: METHODS.SetBackgroundLightAdjust,
                     id: (int)METHODS.SetBackgroundLightAdjust,
                     parameters: parameters);
@@ -45,7 +45,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightBrightness,
                 id: (int)METHODS.SetBackgroundLightBrightness,
                 parameters: parameters);
@@ -65,7 +65,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundColorTemperature,
                 id: (int)METHODS.SetBackgroundColorTemperature,
                 parameters: parameters);
@@ -86,7 +86,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightHSVColor,
                 id: (int)METHODS.SetBackgroundLightHSVColor,
                 parameters: parameters);
@@ -101,7 +101,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> BackgroundSetPower(bool state = true)
         {
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightPower,
                 id: (int)METHODS.SetBackgroundLightPower,
                 parameters: new List<object>() { state ? "on" : "off" }
@@ -126,7 +126,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightRGBColor,
                 id: (int)METHODS.SetBackgroundLightRGBColor,
                 parameters: parameters);
@@ -145,7 +145,7 @@ namespace YeelightAPI
         {
             List<object> parameters = new List<object>() { flow.RepetitionCount, (int)flow.EndAction, flow.GetColorFlowExpression() };
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.StartBackgroundLightColorFlow,
                 id: (int)METHODS.StartBackgroundLightColorFlow,
                 parameters: parameters);
@@ -159,7 +159,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> BackgroundStopColorFlow()
         {
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.StopBackgroundLightColorFlow,
                             id: (int)METHODS.StopBackgroundLightColorFlow);
 
@@ -172,7 +172,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> BackgroundToggle()
         {
-            CommandResult result = await ExecuteCommandWithResponse(METHODS.ToggleBackgroundLight, id: (int)METHODS.ToggleBackgroundLight);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleBackgroundLight, id: (int)METHODS.ToggleBackgroundLight);
 
             return result.IsOk();
         }
@@ -183,7 +183,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> DevToggle()
         {
-            CommandResult result = await ExecuteCommandWithResponse(METHODS.ToggleDev, id: (int)METHODS.ToggleDev);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleDev, id: (int)METHODS.ToggleDev);
 
             return result.IsOk();
         }

--- a/YeelightAPI/Device.IDeviceController.cs
+++ b/YeelightAPI/Device.IDeviceController.cs
@@ -63,7 +63,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> Toggle()
         {
-            CommandResult result = await ExecuteCommandWithResponse(METHODS.Toggle, id: (int)METHODS.Toggle);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.Toggle, id: (int)METHODS.Toggle);
 
             return result.IsOk();
         }
@@ -75,7 +75,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> SetPower(bool state = true)
         {
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetPower,
                 id: (int)METHODS.SetPower,
                 parameters: new List<object>() { state ? "on" : "off" }
@@ -96,7 +96,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBrightness,
                 id: (int)METHODS.SetBrightness,
                 parameters: parameters);
@@ -120,7 +120,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetRGBColor,
                 id: (int)METHODS.SetRGBColor,
                 parameters: parameters);
@@ -140,7 +140,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetColorTemperature,
                 id: (int)METHODS.SetColorTemperature,
                 parameters: parameters);
@@ -161,7 +161,7 @@ namespace YeelightAPI
 
             HandleSmoothValue(ref parameters, smooth);
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetHSVColor,
                 id: (int)METHODS.SetHSVColor,
                 parameters: parameters);
@@ -180,7 +180,7 @@ namespace YeelightAPI
         {
             List<object> parameters = new List<object>() { flow.RepetitionCount, (int)flow.EndAction, flow.GetColorFlowExpression() };
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.StartColorFlow,
                 id: (int)METHODS.StartColorFlow,
                 parameters: parameters);
@@ -194,7 +194,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> StopColorFlow()
         {
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.StopColorFlow,
                             id: (int)METHODS.StopColorFlow);
 
@@ -211,7 +211,7 @@ namespace YeelightAPI
         {
             List<object> parameters = new List<object>() { action.ToString(), property.ToString() };
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetAdjust,
                 id: (int)METHODS.SetAdjust,
                 parameters: parameters);
@@ -229,7 +229,7 @@ namespace YeelightAPI
         {
             List<object> parameters = new List<object>() { (int)type, value };
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AddCron,
                 id: (int)METHODS.AddCron,
                 parameters: parameters);
@@ -246,7 +246,7 @@ namespace YeelightAPI
         {
             List<object> parameters = new List<object>() { (int)type };
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.DeleteCron,
                 id: (int)METHODS.DeleteCron,
                 parameters: parameters);

--- a/YeelightAPI/Device.IDeviceController.cs
+++ b/YeelightAPI/Device.IDeviceController.cs
@@ -49,12 +49,18 @@ namespace YeelightAPI
 #pragma warning restore 4014
 
             //initialiazing all properties
-            foreach (KeyValuePair<PROPERTIES, object> property in await GetAllProps())
-            {
-                this[property.Key] = property.Value;
-            }
+            Dictionary<PROPERTIES, object> properties = await GetAllProps();
 
-            return true;
+            if (properties != null)
+            {
+                foreach (KeyValuePair<PROPERTIES, object> property in properties)
+                {
+                    this[property.Key] = property.Value;
+                }
+
+                return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/YeelightAPI/Device.IDeviceReader.cs
+++ b/YeelightAPI/Device.IDeviceReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using YeelightAPI.Models;
 using YeelightAPI.Models.Cron;
@@ -22,12 +23,12 @@ namespace YeelightAPI
         {
             List<object> parameters = new List<object>() { (int)type };
 
-            CommandResult<CronResult> result = await ExecuteCommandWithResponse<CronResult>(
+            CommandResult<CronResult[]> result = await ExecuteCommandWithResponse<CronResult[]>(
                             method: METHODS.GetCron,
                             id: (int)METHODS.GetCron,
                             parameters: parameters);
 
-            return result?.Result;
+            return result?.Result.FirstOrDefault();
         }
 
         /// <summary>
@@ -48,7 +49,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<object> GetProp(PROPERTIES prop)
         {
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.GetProp,
                 id: (int)METHODS.GetProp,
                 parameters: new List<object>() { prop.ToString() }
@@ -66,7 +67,7 @@ namespace YeelightAPI
         {
             List<object> names = props.GetRealNames();
 
-            CommandResult commandResult = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> commandResult = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.GetProp,
                 id: ((int)METHODS.GetProp),// + 1000 + props.Count,
                 parameters: names
@@ -96,7 +97,7 @@ namespace YeelightAPI
         {
             List<object> parameters = new List<object>() { name };
 
-            CommandResult result = await ExecuteCommandWithResponse(
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.SetName,
                             id: (int)METHODS.SetName,
                             parameters: parameters);

--- a/YeelightAPI/Device.IDeviceReader.cs
+++ b/YeelightAPI/Device.IDeviceReader.cs
@@ -28,7 +28,7 @@ namespace YeelightAPI
                             id: (int)METHODS.GetCron,
                             parameters: parameters);
 
-            return result?.Result.FirstOrDefault();
+            return result?.Result?.FirstOrDefault();
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace YeelightAPI
                 parameters: new List<object>() { prop.ToString() }
                 );
 
-            return result.Result != null && result.Result.Count == 1 ? result.Result[0] : null;
+            return result?.Result?.Count == 1 ? result.Result[0] : null;
         }
 
         /// <summary>
@@ -73,19 +73,23 @@ namespace YeelightAPI
                 parameters: names
                 );
 
-            Dictionary<PROPERTIES, object> result = new Dictionary<PROPERTIES, object>();
-
-            for (int n = 0; n < names.Count; n++)
+            if (commandResult != null)
             {
-                string name = names[n].ToString();
+                Dictionary<PROPERTIES, object> result = new Dictionary<PROPERTIES, object>();
 
-                if (Enum.TryParse<PROPERTIES>(name, out PROPERTIES p))
+                for (int n = 0; n < names.Count; n++)
                 {
-                    result.Add(p, commandResult.Result[n]);
-                }
-            }
+                    string name = names[n].ToString();
 
-            return result;
+                    if (Enum.TryParse<PROPERTIES>(name, out PROPERTIES p))
+                    {
+                        result.Add(p, commandResult.Result[n]);
+                    }
+                }
+
+                return result;
+            }
+            return null;
         }
 
         /// <summary>
@@ -109,7 +113,7 @@ namespace YeelightAPI
             }
             else
             {
-                return result.IsOk();
+                return false;
             }
         }
 

--- a/YeelightAPI/Models/CommandResult.cs
+++ b/YeelightAPI/Models/CommandResult.cs
@@ -16,7 +16,7 @@ namespace YeelightAPI.Models
         /// <returns></returns>
         public static bool IsOk(this CommandResult<List<string>> @this)
         {
-            return @this != null && @this.Error == null && @this.Result?[0] == "ok";
+            return @this?.Error == null && @this?.Result?[0] == "ok";
         }
 
         #endregion Public Methods

--- a/YeelightAPI/Models/CommandResult.cs
+++ b/YeelightAPI/Models/CommandResult.cs
@@ -14,7 +14,7 @@ namespace YeelightAPI.Models
         /// </summary>
         /// <param name="this"></param>
         /// <returns></returns>
-        public static bool IsOk(this CommandResult @this)
+        public static bool IsOk(this CommandResult<List<string>> @this)
         {
             return @this != null && @this.Error == null && @this.Result?[0] == "ok";
         }
@@ -25,12 +25,7 @@ namespace YeelightAPI.Models
     /// <summary>
     /// Default command result
     /// </summary>
-    public class CommandResult : CommandResult<List<string>> { }
-
-    /// <summary>
-    /// Result received after a Command has been sent
-    /// </summary>
-    public class CommandResult<T>
+    public class CommandResult
     {
         #region Public Properties
 
@@ -43,11 +38,6 @@ namespace YeelightAPI.Models
         /// Request Id (mirrored from the sent request)
         /// </summary>
         public int Id { get; set; }
-
-        /// <summary>
-        /// Result
-        /// </summary>
-        public T Result { get; set; }
 
         #endregion Public Properties
 
@@ -87,5 +77,21 @@ namespace YeelightAPI.Models
         }
 
         #endregion Public Classes
+    }
+
+    /// <summary>
+    /// Result received after a Command has been sent
+    /// </summary>
+    public class CommandResult<T> : CommandResult
+    {
+        #region Public Properties
+
+        /// <summary>
+        /// Result
+        /// </summary>
+        public T Result { get; set; }
+
+        #endregion Public Properties
+
     }
 }

--- a/YeelightAPIConsoleTest/Program.cs
+++ b/YeelightAPIConsoleTest/Program.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using YeelightAPI;
 using YeelightAPI.Models;
 using YeelightAPI.Models.ColorFlow;
+using YeelightAPI.Models.Cron;
 
 namespace YeelightAPIConsoleTest
 {
@@ -92,25 +93,6 @@ namespace YeelightAPIConsoleTest
 
                         device.OnNotificationReceived += Device_OnNotificationReceived;
 
-                        Console.WriteLine("getting current name ...");
-                        string name = (await device.GetProp(PROPERTIES.name))?.ToString();
-                        Console.WriteLine($"current name : {name}");
-
-                        Console.WriteLine("setting name 'test' ...");
-                        success &= await device.SetName("test");
-                        WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
-                        await Task.Delay(2000);
-
-                        Console.WriteLine("restoring name '{0}' ...", name);
-                        success &= await device.SetName(name);
-                        WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
-                        await Task.Delay(2000);
-
-                        Console.WriteLine("getting all props ...");
-                        Dictionary<PROPERTIES, object> result = await device.GetAllProps();
-                        Console.WriteLine($"\tprops : {JsonConvert.SerializeObject(result)}");
-                        await Task.Delay(2000);
-
                         //without smooth value (sudden)
                         WriteLineWithColor("Processing tests", ConsoleColor.Cyan);
                         success &= await ExecuteTests(device, null);
@@ -155,6 +137,45 @@ namespace YeelightAPIConsoleTest
 
             Console.WriteLine("powering on ...");
             success = await device.SetPower(true);
+            globalSuccess &= success;
+            WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
+            await Task.Delay(delay);
+
+            Console.WriteLine("add cron ...");
+            success = await device.CronAdd(15, YeelightAPI.Models.Cron.CronType.PowerOff);
+            globalSuccess &= success;
+            WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
+            await Task.Delay(delay);
+
+            if (device is IDeviceReader deviceReader)
+            {
+                Console.WriteLine("get cron ...");
+                CronResult cronResult = await deviceReader.CronGet(YeelightAPI.Models.Cron.CronType.PowerOff);
+                globalSuccess &= (cronResult != null);
+                WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
+                await Task.Delay(delay);
+
+                Console.WriteLine("getting current name ...");
+                string name = (await deviceReader.GetProp(PROPERTIES.name))?.ToString();
+                Console.WriteLine($"current name : {name}");
+
+                Console.WriteLine("setting name 'test' ...");
+                success &= await deviceReader.SetName("test");
+                WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
+                await Task.Delay(2000);
+
+                Console.WriteLine("restoring name '{0}' ...", name);
+                success &= await deviceReader.SetName(name);
+                WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
+                await Task.Delay(2000);
+
+                Console.WriteLine("getting all props ...");
+                Dictionary<PROPERTIES, object> result = await deviceReader.GetAllProps();
+                Console.WriteLine($"\tprops : {JsonConvert.SerializeObject(result)}");
+                await Task.Delay(2000);
+            }
+            Console.WriteLine("delete cron ...");
+            success = await device.CronDelete(YeelightAPI.Models.Cron.CronType.PowerOff);
             globalSuccess &= success;
             WriteLineWithColor($"command success : {success}", ConsoleColor.DarkCyan);
             await Task.Delay(delay);

--- a/YeelightAPIConsoleTest/Program.cs
+++ b/YeelightAPIConsoleTest/Program.cs
@@ -42,7 +42,6 @@ namespace YeelightAPIConsoleTest
                             foreach (Device device in group)
                             {
                                 device.OnNotificationReceived += Device_OnNotificationReceived;
-                                device.OnCommandError += Device_OnCommandError;
                             }
 
                             bool success = true;
@@ -92,7 +91,6 @@ namespace YeelightAPIConsoleTest
                         success &= await device.Connect();
 
                         device.OnNotificationReceived += Device_OnNotificationReceived;
-                        device.OnCommandError += Device_OnCommandError;
 
                         Console.WriteLine("getting current name ...");
                         string name = (await device.GetProp(PROPERTIES.name))?.ToString();
@@ -144,11 +142,6 @@ namespace YeelightAPIConsoleTest
         #endregion Public Methods
 
         #region Private Methods
-
-        private static void Device_OnCommandError(object sender, CommandErrorEventArgs arg)
-        {
-            WriteLineWithColor($"An error occurred : {arg.Error}", ConsoleColor.DarkRed);
-        }
 
         private static void Device_OnNotificationReceived(object sender, NotificationReceivedEventArgs arg)
         {


### PR DESCRIPTION
I tried to fix #3, but somehow this PR got somewhat big. 😟 

First, I had to change the result classes. As I wrote in #3, you cannot cast from `CommandResult<List<string>>` to `CommandResult<CronResult>`.
Therefore I reversed the class hierarchie: the base `CommandResult` has `Id` and `Error` only. If `Device.Watch` can deserialize the Id, it gets the actual handler from `_commandResultHandlers`, which returns the concrete closed type of the `CommandResult`.

This handler also uses `TaskCompletionSource` to get rid of the polling: in `Device.ExecuteCommandWithResponse` it creates the `CommandResultHandler` objects and immediately returns the provided `Task`. When the result is received from the device, it will set the result of the enclosed `TaskCompletionSource`, so any awaiting code can continue.

Additionally, I have removed the `Device.OnCommandError` event. Instead, if an error is received from the device, it will call `SetException` on the `TaskCompletionSource`, so the awaiting caller will get an exception.

This PR is a proposal, with no further comments or documentation in the code. That's why I have added `[RFC]` in the title. What do you think about this changes? I'm on vacation from 17th till 21th, so I won't be able to answer before next Thursday.