### PR TITLE
rename Constantes to Constants

### DIFF
--- a/YeelightAPI/Core/CommandResultHandler.cs
+++ b/YeelightAPI/Core/CommandResultHandler.cs
@@ -16,7 +16,7 @@ namespace YeelightAPI.Core
         /// <summary>
         /// Cancellation Token Source
         /// </summary>
-        private readonly CancellationTokenSource _cts = new CancellationTokenSource(Constantes.DefaultTimeout);
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource(Constants.DefaultTimeout);
 
         /// <summary>
         /// Task Completion Source

--- a/YeelightAPI/Core/Constants.cs
+++ b/YeelightAPI/Core/Constants.cs
@@ -6,7 +6,7 @@ namespace YeelightAPI.Core
     /// <summary>
     /// Common
     /// </summary>
-    internal class Constantes
+    internal class Constants
     {
         #region Public Fields
 

--- a/YeelightAPI/Core/Constants.cs
+++ b/YeelightAPI/Core/Constants.cs
@@ -6,7 +6,7 @@ namespace YeelightAPI.Core
     /// <summary>
     /// Common
     /// </summary>
-    internal class Constants
+    internal static class Constants
     {
         #region Public Fields
 

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -83,7 +83,7 @@ namespace YeelightAPI
         /// <param name="hostname"></param>
         /// <param name="port"></param>
         /// <param name="autoConnect"></param>
-        public Device(string hostname, int port = Constantes.DefaultPort, bool autoConnect = false)
+        public Device(string hostname, int port = Constants.DefaultPort, bool autoConnect = false)
         {
             Hostname = hostname;
             Port = port;
@@ -203,8 +203,8 @@ namespace YeelightAPI
                 Params = parameters ?? new List<object>()
             };
 
-            string data = JsonConvert.SerializeObject(command, Constantes.DeviceSerializerSettings);
-            byte[] sentData = Encoding.ASCII.GetBytes(data + Constantes.LineSeparator); // \r\n is the end of the message, it needs to be sent for the message to be read by the device
+            string data = JsonConvert.SerializeObject(command, Constants.DeviceSerializerSettings);
+            byte[] sentData = Encoding.ASCII.GetBytes(data + Constants.LineSeparator); // \r\n is the end of the message, it needs to be sent for the message to be read by the device
 
             lock (_syncLock)
             {
@@ -250,7 +250,7 @@ namespace YeelightAPI
             if (smooth.HasValue)
             {
                 parameters.Add("smooth");
-                parameters.Add(Math.Max(smooth.Value, Constantes.MinimumSmoothDuration));
+                parameters.Add(Math.Max(smooth.Value, Constants.MinimumSmoothDuration));
             }
             else
             {
@@ -315,11 +315,11 @@ namespace YeelightAPI
                                 if (!string.IsNullOrEmpty(datas))
                                 {
                                     //get every messages in the pipe
-                                    foreach (string entry in datas.Split(new string[] { Constantes.LineSeparator },
+                                    foreach (string entry in datas.Split(new string[] { Constants.LineSeparator },
                                         StringSplitOptions.RemoveEmptyEntries))
                                     {
                                         CommandResult commandResult =
-                                            JsonConvert.DeserializeObject<CommandResult>(entry, Constantes.DeviceSerializerSettings);
+                                            JsonConvert.DeserializeObject<CommandResult>(entry, Constants.DeviceSerializerSettings);
                                         if (commandResult != null && commandResult.Id != 0)
                                         {
                                             ICommandResultHandler commandResultHandler;
@@ -330,7 +330,7 @@ namespace YeelightAPI
 
                                             if (commandResult.Error == null)
                                             {
-                                                commandResult = (CommandResult)JsonConvert.DeserializeObject(entry, commandResultHandler.ResultType, Constantes.DeviceSerializerSettings);
+                                                commandResult = (CommandResult)JsonConvert.DeserializeObject(entry, commandResultHandler.ResultType, Constants.DeviceSerializerSettings);
                                                 commandResultHandler.SetResult(commandResult);
                                             }
                                             else
@@ -342,7 +342,7 @@ namespace YeelightAPI
                                         {
                                             NotificationResult notificationResult =
                                                 JsonConvert.DeserializeObject<NotificationResult>(entry,
-                                                    Constantes.DeviceSerializerSettings);
+                                                    Constants.DeviceSerializerSettings);
 
                                             if (notificationResult != null && notificationResult.Method != null)
                                             {

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -120,9 +120,9 @@ namespace YeelightAPI
         {
             if (ssdpMessage != null)
             {
-                string[] split = ssdpMessage.Split(new string[] { Constantes.LineSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                string[] split = ssdpMessage.Split(new string[] { Constants.LineSeparator }, StringSplitOptions.RemoveEmptyEntries);
                 string host = null;
-                int port = Constantes.DefaultPort;
+                int port = Constants.DefaultPort;
                 Dictionary<string, object> properties = new Dictionary<string, object>();
 
                 foreach (string part in split)

--- a/YeelightAPI/Models/ColorFlow/ColorFlowRGBExpression.cs
+++ b/YeelightAPI/Models/ColorFlow/ColorFlowRGBExpression.cs
@@ -17,7 +17,7 @@ namespace YeelightAPI.Models.ColorFlow
         /// <param name="b"></param>
         /// <param name="duration"></param>
         /// <param name="brightness"></param>
-        public ColorFlowRGBExpression(int r, int g, int b, int brightness, int duration = Constantes.MinimumFlowExpressionDuration)
+        public ColorFlowRGBExpression(int r, int g, int b, int brightness, int duration = Constants.MinimumFlowExpressionDuration)
         {
             Duration = duration;
             Value = ColorHelper.ComputeRGBColor(r, g, b);

--- a/YeelightAPI/Models/ColorFlow/ColorFlowSleepExpression.cs
+++ b/YeelightAPI/Models/ColorFlow/ColorFlowSleepExpression.cs
@@ -13,7 +13,7 @@ namespace YeelightAPI.Models.ColorFlow
         /// Constructor
         /// </summary>
         /// <param name="duration"></param>
-        public ColorFlowSleepExpression(int duration = Constantes.MinimumFlowExpressionDuration)
+        public ColorFlowSleepExpression(int duration = Constants.MinimumFlowExpressionDuration)
         {
             Duration = duration;
             Mode = ColorFlowMode.Sleep;

--- a/YeelightAPI/Models/ColorFlow/ColorTemperatureFlowExpression.cs
+++ b/YeelightAPI/Models/ColorFlow/ColorTemperatureFlowExpression.cs
@@ -15,7 +15,7 @@ namespace YeelightAPI.Models.ColorFlow
         /// <param name="temperature"></param>
         /// <param name="duration"></param>
         /// <param name="brightness"></param>
-        public ColorFlowTemperatureExpression(int temperature, int brightness, int duration = Constantes.MinimumFlowExpressionDuration)
+        public ColorFlowTemperatureExpression(int temperature, int brightness, int duration = Constants.MinimumFlowExpressionDuration)
         {
             Duration = duration;
             Mode = ColorFlowMode.ColorTemperature;


### PR DESCRIPTION
The PR renames `Constantes` to `Constants`.

Additionally, `Constants` is now static, because it only has static members and will never be instantiated.