### PR TITLE
Add property to check if there is a connection to Device

### DIFF
--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -83,6 +83,11 @@ namespace YeelightAPI
         /// </summary>
         public int Port { get; }
 
+        /// <summary>
+        /// Gets a value indicating if the connection to Device is established
+        /// </summary>
+        public bool IsConnected { get { return (_tcpClient != null) ? _tcpClient.Connected : false; } }
+
         #endregion PUBLIC PROPERTIES
 
         #region CONSTRUCTOR

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -74,6 +74,17 @@ namespace YeelightAPI
         public string Id { get; }
 
         /// <summary>
+        /// Gets a value indicating if the connection to Device is established
+        /// </summary>
+        public bool IsConnected
+        {
+            get
+            {
+                return _tcpClient?.Connected ?? false;
+            }
+        }
+
+        /// <summary>
         /// The model.
         /// </summary>
         public MODEL Model { get; }
@@ -82,11 +93,6 @@ namespace YeelightAPI
         /// Port number
         /// </summary>
         public int Port { get; }
-
-        /// <summary>
-        /// Gets a value indicating if the connection to Device is established
-        /// </summary>
-        public bool IsConnected { get { return (_tcpClient != null) ? _tcpClient.Connected : false; } }
 
         #endregion PUBLIC PROPERTIES
 


### PR DESCRIPTION
Adds a property to Device.cs to check whether the underlying TcpClient connection is established.

This should be useful as it is required to Connect() and Disconnect(), and so this provides a way to keep track of the connection state