### PR TITLE
Use a unique ID for every command.

### DIFF
--- a/YeelightAPI/Device.IBackgroundDeviceController.cs
+++ b/YeelightAPI/Device.IBackgroundDeviceController.cs
@@ -33,7 +33,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.BackgroundAdjustBright,
-                id: (int)METHODS.BackgroundAdjustBright,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -56,7 +56,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.BackgroundAdjustColor,
-                id: (int)METHODS.BackgroundAdjustColor,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -79,7 +79,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.BackgroundAdjustColorTemperature,
-                id: (int)METHODS.BackgroundAdjustColorTemperature,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -106,7 +106,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightAdjust,
-                id: (int)METHODS.SetBackgroundLightAdjust,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -126,7 +126,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightBrightness,
-                id: (int)METHODS.SetBackgroundLightBrightness,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -146,7 +146,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundColorTemperature,
-                id: (int)METHODS.SetBackgroundColorTemperature,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -158,7 +158,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> BackgroundSetDefault()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetBackgroundLightDefault, id: (int)METHODS.SetBackgroundLightDefault);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetBackgroundLightDefault, id: GetUniqueIdForCommand());
 
             return result.IsOk();
         }
@@ -178,7 +178,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightHSVColor,
-                id: (int)METHODS.SetBackgroundLightHSVColor,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -199,7 +199,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightPower,
-                id: (int)METHODS.SetBackgroundLightPower,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters
             );
 
@@ -224,7 +224,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightRGBColor,
-                id: (int)METHODS.SetBackgroundLightRGBColor,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -241,7 +241,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightScene,
-                id: (int)METHODS.SetBackgroundLightScene,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -258,7 +258,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.StartBackgroundLightColorFlow,
-                id: (int)METHODS.StartBackgroundLightColorFlow,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -272,7 +272,7 @@ namespace YeelightAPI
         {
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.StopBackgroundLightColorFlow,
-                            id: (int)METHODS.StopBackgroundLightColorFlow);
+                            id: GetUniqueIdForCommand());
 
             return result.IsOk();
         }
@@ -283,7 +283,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> BackgroundToggle()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleBackgroundLight, id: (int)METHODS.ToggleBackgroundLight);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleBackgroundLight, id: GetUniqueIdForCommand());
 
             return result.IsOk();
         }
@@ -300,7 +300,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightPower,
-                id: (int)METHODS.SetBackgroundLightPower,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -320,7 +320,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightPower,
-                id: (int)METHODS.SetBackgroundLightPower,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -332,7 +332,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> DevToggle()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleDev, id: (int)METHODS.ToggleDev);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleDev, id: GetUniqueIdForCommand());
 
             return result.IsOk();
         }

--- a/YeelightAPI/Device.IBackgroundDeviceController.cs
+++ b/YeelightAPI/Device.IBackgroundDeviceController.cs
@@ -33,7 +33,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.BackgroundAdjustBright,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -56,7 +55,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.BackgroundAdjustColor,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -79,7 +77,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.BackgroundAdjustColorTemperature,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -106,7 +103,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightAdjust,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -126,7 +122,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightBrightness,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -146,7 +141,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundColorTemperature,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -158,7 +152,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> BackgroundSetDefault()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetBackgroundLightDefault, id: GetUniqueIdForCommand());
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetBackgroundLightDefault);
 
             return result.IsOk();
         }
@@ -178,7 +172,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightHSVColor,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -199,7 +192,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightPower,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters
             );
 
@@ -224,7 +216,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightRGBColor,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -241,7 +232,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightScene,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -258,7 +248,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.StartBackgroundLightColorFlow,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -271,8 +260,7 @@ namespace YeelightAPI
         public async Task<bool> BackgroundStopColorFlow()
         {
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
-                            method: METHODS.StopBackgroundLightColorFlow,
-                            id: GetUniqueIdForCommand());
+                            method: METHODS.StopBackgroundLightColorFlow);
 
             return result.IsOk();
         }
@@ -283,7 +271,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> BackgroundToggle()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleBackgroundLight, id: GetUniqueIdForCommand());
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleBackgroundLight);
 
             return result.IsOk();
         }
@@ -300,7 +288,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightPower,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -320,7 +307,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBackgroundLightPower,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -332,7 +318,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> DevToggle()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleDev, id: GetUniqueIdForCommand());
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.ToggleDev);
 
             return result.IsOk();
         }

--- a/YeelightAPI/Device.IDeviceController.cs
+++ b/YeelightAPI/Device.IDeviceController.cs
@@ -34,7 +34,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AdjustBright,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -57,7 +56,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AdjustColor,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -80,7 +78,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AdjustColorTemperature,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -136,7 +133,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AddCron,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -153,7 +149,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.DeleteCron,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -193,7 +188,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetAdjust,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -213,7 +207,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBrightness,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -233,7 +226,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetColorTemperature,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -245,7 +237,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> SetDefault()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetDefault, id: GetUniqueIdForCommand());
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetDefault);
 
             return result.IsOk();
         }
@@ -265,7 +257,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetHSVColor,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -286,7 +277,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetPower,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters
             );
 
@@ -311,7 +301,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetRGBColor,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -328,7 +317,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetScene,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -345,7 +333,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.StartColorFlow,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -363,7 +350,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.SetMusicMode,
-                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             return result.IsOk();
@@ -376,8 +362,7 @@ namespace YeelightAPI
         public async Task<bool> StopColorFlow()
         {
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
-                            method: METHODS.StopColorFlow,
-                            id: GetUniqueIdForCommand());
+                            method: METHODS.StopColorFlow);
 
             return result.IsOk();
         }
@@ -392,7 +377,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.SetMusicMode,
-                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             return result.IsOk();
@@ -404,7 +388,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> Toggle()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.Toggle, id: GetUniqueIdForCommand());
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.Toggle);
 
             return result.IsOk();
         }
@@ -421,7 +405,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetPower,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -441,7 +424,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetPower,
-                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();

--- a/YeelightAPI/Device.IDeviceController.cs
+++ b/YeelightAPI/Device.IDeviceController.cs
@@ -34,7 +34,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AdjustBright,
-                id: (int)METHODS.AdjustBright,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -57,7 +57,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AdjustColor,
-                id: (int)METHODS.AdjustColor,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -80,7 +80,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AdjustColorTemperature,
-                id: (int)METHODS.AdjustColorTemperature,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -136,7 +136,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.AddCron,
-                id: (int)METHODS.AddCron,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -153,7 +153,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.DeleteCron,
-                id: (int)METHODS.DeleteCron,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -193,7 +193,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetAdjust,
-                id: (int)METHODS.SetAdjust,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -213,7 +213,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetBrightness,
-                id: (int)METHODS.SetBrightness,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -233,7 +233,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetColorTemperature,
-                id: (int)METHODS.SetColorTemperature,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -245,7 +245,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> SetDefault()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetDefault, id: (int)METHODS.SetDefault);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.SetDefault, id: GetUniqueIdForCommand());
 
             return result.IsOk();
         }
@@ -265,7 +265,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetHSVColor,
-                id: (int)METHODS.SetHSVColor,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -286,7 +286,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetPower,
-                id: (int)METHODS.SetPower,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters
             );
 
@@ -311,7 +311,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetRGBColor,
-                id: (int)METHODS.SetRGBColor,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -328,7 +328,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetScene,
-                id: (int)METHODS.SetScene,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -345,7 +345,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.StartColorFlow,
-                id: (int)METHODS.StartColorFlow,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -363,7 +363,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.SetMusicMode,
-                            id: (int)METHODS.SetMusicMode,
+                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             return result.IsOk();
@@ -377,7 +377,7 @@ namespace YeelightAPI
         {
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.StopColorFlow,
-                            id: (int)METHODS.StopColorFlow);
+                            id: GetUniqueIdForCommand());
 
             return result.IsOk();
         }
@@ -392,7 +392,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.SetMusicMode,
-                            id: (int)METHODS.SetMusicMode,
+                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             return result.IsOk();
@@ -404,7 +404,7 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> Toggle()
         {
-            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.Toggle, id: (int)METHODS.Toggle);
+            CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(METHODS.Toggle, id: GetUniqueIdForCommand());
 
             return result.IsOk();
         }
@@ -421,7 +421,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetPower,
-                id: (int)METHODS.SetPower,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();
@@ -441,7 +441,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.SetPower,
-                id: (int)METHODS.SetPower,
+                id: GetUniqueIdForCommand(),
                 parameters: parameters);
 
             return result.IsOk();

--- a/YeelightAPI/Device.IDeviceReader.cs
+++ b/YeelightAPI/Device.IDeviceReader.cs
@@ -26,7 +26,6 @@ namespace YeelightAPI
 
             CommandResult<CronResult[]> result = await ExecuteCommandWithResponse<CronResult[]>(
                             method: METHODS.GetCron,
-                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             return result?.Result?.FirstOrDefault();
@@ -52,9 +51,7 @@ namespace YeelightAPI
         {
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.GetProp,
-                id: GetUniqueIdForCommand(),
-                parameters: new List<object>() { prop.ToString() }
-                );
+                parameters: new List<object>() { prop.ToString() } );
 
             return result?.Result?.Count == 1 ? result.Result[0] : null;
         }
@@ -72,7 +69,6 @@ namespace YeelightAPI
             {
                 CommandResult<List<string>> commandResult = await ExecuteCommandWithResponse<List<string>>(
                     method: METHODS.GetProp,
-                    id: GetUniqueIdForCommand(),
                     parameters: names
                     );
 
@@ -83,14 +79,10 @@ namespace YeelightAPI
 
                 CommandResult<List<string>> commandResult1 = await ExecuteCommandWithResponse<List<string>>(
                     method: METHODS.GetProp,
-                    id: GetUniqueIdForCommand(),
-                    parameters: names.Take(20).ToList()
-                    );
+                    parameters: names.Take(20).ToList() );
                 CommandResult<List<string>> commandResult2 = await ExecuteCommandWithResponse<List<string>>(
                     method: METHODS.GetProp,
-                    id: GetUniqueIdForCommand(),
-                    parameters: names.Skip(20).ToList()
-                    );
+                    parameters: names.Skip(20).ToList());
 
                 results.AddRange(commandResult1?.Result);
                 results.AddRange(commandResult2?.Result);
@@ -126,7 +118,6 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.SetName,
-                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             if (result.IsOk())

--- a/YeelightAPI/Device.IDeviceReader.cs
+++ b/YeelightAPI/Device.IDeviceReader.cs
@@ -26,7 +26,7 @@ namespace YeelightAPI
 
             CommandResult<CronResult[]> result = await ExecuteCommandWithResponse<CronResult[]>(
                             method: METHODS.GetCron,
-                            id: (int)METHODS.GetCron,
+                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             return result?.Result?.FirstOrDefault();
@@ -52,7 +52,7 @@ namespace YeelightAPI
         {
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                 method: METHODS.GetProp,
-                id: (int)METHODS.GetProp,
+                id: GetUniqueIdForCommand(),
                 parameters: new List<object>() { prop.ToString() }
                 );
 
@@ -72,7 +72,7 @@ namespace YeelightAPI
             {
                 CommandResult<List<string>> commandResult = await ExecuteCommandWithResponse<List<string>>(
                     method: METHODS.GetProp,
-                    id: ((int)METHODS.GetProp),// + 1000 + props.Count,
+                    id: GetUniqueIdForCommand(),
                     parameters: names
                     );
 
@@ -83,12 +83,12 @@ namespace YeelightAPI
 
                 CommandResult<List<string>> commandResult1 = await ExecuteCommandWithResponse<List<string>>(
                     method: METHODS.GetProp,
-                    id: ((int)METHODS.GetProp),// + 1000 + props.Count,
+                    id: GetUniqueIdForCommand(),
                     parameters: names.Take(20).ToList()
                     );
                 CommandResult<List<string>> commandResult2 = await ExecuteCommandWithResponse<List<string>>(
                     method: METHODS.GetProp,
-                    id: ((int)METHODS.GetProp),// + 1000 + props.Count,
+                    id: GetUniqueIdForCommand(),
                     parameters: names.Skip(20).ToList()
                     );
 
@@ -126,7 +126,7 @@ namespace YeelightAPI
 
             CommandResult<List<string>> result = await ExecuteCommandWithResponse<List<string>>(
                             method: METHODS.SetName,
-                            id: (int)METHODS.SetName,
+                            id: GetUniqueIdForCommand(),
                             parameters: parameters);
 
             if (result.IsOk())

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using YeelightAPI.Core;
 using YeelightAPI.Models;
@@ -25,6 +26,11 @@ namespace YeelightAPI
         /// lock
         /// </summary>
         private readonly object _syncLock = new object();
+
+        /// <summary>
+        /// The unique id to send when executing a command.
+        /// </summary>
+        private int _uniqueId = 0;
 
         /// <summary>
         /// TCP client used to communicate with the device
@@ -474,6 +480,11 @@ namespace YeelightAPI
                     await Task.Delay(100);
                 }
             }, TaskCreationOptions.LongRunning);
+        }
+
+        private int GetUniqueIdForCommand()
+        {
+            return Interlocked.Increment(ref _uniqueId);
         }
 
         #endregion PRIVATE METHODS

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -235,9 +235,20 @@ namespace YeelightAPI
         /// Execute a command
         /// </summary>
         /// <param name="method"></param>
+        /// <param name="parameters"></param>
+        public void ExecuteCommand(METHODS method, List<object> parameters = null)
+        {
+            ExecuteCommand(method, GetUniqueIdForCommand(), parameters);
+        }
+
+        /// <summary>
+        /// Execute a command
+        /// </summary>
+        /// <param name="method"></param>
         /// <param name="id"></param>
         /// <param name="parameters"></param>
-        public void ExecuteCommand(METHODS method, int id = 0, List<object> parameters = null)
+        [Obsolete("Will become internal in a future release, use 'ExecuteCommand(METHODS method, List<object> parameters = null)' instead")]
+        public void ExecuteCommand(METHODS method, int id, List<object> parameters = null)
         {
             if (!IsMethodSupported(method))
             {
@@ -265,10 +276,23 @@ namespace YeelightAPI
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="method"></param>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public async Task<CommandResult<T>> ExecuteCommandWithResponse<T>(METHODS method, List<object> parameters = null)
+        {
+            return await ExecuteCommandWithResponse<T>(method, GetUniqueIdForCommand(), parameters);
+        }
+
+        /// <summary>
+        /// Execute a command and waits for a response
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="method"></param>
         /// <param name="id"></param>
         /// <param name="parameters"></param>
         /// <returns></returns>
-        public async Task<CommandResult<T>> ExecuteCommandWithResponse<T>(METHODS method, int id = 0, List<object> parameters = null)
+        [Obsolete("Will become internal in a future release, use 'ExecuteCommandWithResponse<T>(METHODS method, List<object> parameters = null)' instead")]
+        public async Task<CommandResult<T>> ExecuteCommandWithResponse<T>(METHODS method, int id, List<object> parameters = null)
         {
             try
             {
@@ -351,7 +375,7 @@ namespace YeelightAPI
             }
 
             return true;
-            //no supported operations, so we can't check if the peration is permitted
+            //no supported operations, so we can't check if the operation is permitted
         }
 
         /// <summary>

--- a/YeelightAPI/Device.cs
+++ b/YeelightAPI/Device.cs
@@ -443,7 +443,8 @@ namespace YeelightAPI
                                                     ICommandResultHandler commandResultHandler;
                                                     lock (_currentCommandResults)
                                                     {
-                                                        commandResultHandler = _currentCommandResults[commandResult.Id];
+                                                        if (!_currentCommandResults.TryGetValue(commandResult.Id, out commandResultHandler))
+                                                            continue; // ignore if the result can't be found
                                                     }
 
                                                     if (commandResult.Error == null)


### PR DESCRIPTION
This is a change to increment the id sent with each command so that command results don't overwrite each other. Previously I would get values like "on" returned when getting the colour and the task completion source result was being set multiple times:

```
[ERROR] - 2018-08-12 03:58:52,855 - YeeLight bulb error.
System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
   at YeelightAPI.Core.CommandResultHandler`1.SetResult(CommandResult commandResult)
   at YeelightAPI.Device.<Watch>b__46_0()
```

IMO, a better fix would be to make `id` internal to the library and only setting it uniquely at one point instead of having to do it all over the place. Anyway, this is a start.