### PR TITLE
repetition parameter in FluentFlow.Play is not used

### DIFF
--- a/YeelightAPI/Models/FluentFlow.cs
+++ b/YeelightAPI/Models/FluentFlow.cs
@@ -67,7 +67,7 @@ namespace YeelightAPI.Models
         {
             CheckExpressions();
 
-            ColorFlow.ColorFlow flow = new ColorFlow.ColorFlow(0, endAction, _expressions);
+            ColorFlow.ColorFlow flow = new ColorFlow.ColorFlow(repetition, endAction, _expressions);
 
             await _startColorFlowMethod(flow);
 

--- a/YeelightAPIConsoleTest/YeelightAPIConsoleTest.csproj
+++ b/YeelightAPIConsoleTest/YeelightAPIConsoleTest.csproj
@@ -35,8 +35,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/YeelightAPIConsoleTest/packages.config
+++ b/YeelightAPIConsoleTest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
This PR fixes the method `FluentFlow.Play` not using the `repetition` parameter.