### PR TITLE
Loop through all IPv4 multicast addresses

### DIFF
--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -104,7 +104,7 @@ namespace YeelightAPI
             try
             {
                 GatewayIPAddressInformation addr = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
-
+                var ipProperties = netInterface.GetIPProperties();
                 if (addr != null && !addr.Address.ToString().Equals("0.0.0.0"))
                 {
                     if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 || netInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
@@ -126,12 +126,12 @@ namespace YeelightAPI
                                                 UseOnlyOverlappedIO = true,
                                                 MulticastLoopback = false,
                                             };
+
                                             ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
                                             ssdpSocket.SetSocketOption(
-                                                SocketOptionLevel.IP,
-                                                SocketOptionName.AddMembership,
+                                                SocketOptionLevel.IP, 
                                                 SocketOptionName.AddMembership, 
-                                                new MulticastOption(multicastEndpoint.Address));
+                                                new MulticastOption(multicastEndpoint.Address, interfaceIndex));
                                             ssdpSocket.SendTo(Encoding.ASCII.GetBytes(string.Format(_ssdpMessageTemplate, multicastEndpoint.Address.ToString())), SocketFlags.None, new IPEndPoint(multicastEndpoint.Address, 1982));
 
                                             DateTime start = DateTime.Now;

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -130,8 +130,9 @@ namespace YeelightAPI
                                             ssdpSocket.SetSocketOption(
                                                 SocketOptionLevel.IP,
                                                 SocketOptionName.AddMembership,
+                                                SocketOptionName.AddMembership, 
                                                 new MulticastOption(multicastEndpoint.Address));
-                                            ssdpSocket.SendTo(_ssdpDiagram, SocketFlags.None, new IPEndPoint(multicastEndpoint.Address, 1982));
+                                            ssdpSocket.SendTo(Encoding.ASCII.GetBytes(string.Format(_ssdpMessageTemplate, multicastEndpoint.Address.ToString())), SocketFlags.None, new IPEndPoint(multicastEndpoint.Address, 1982));
 
                                             DateTime start = DateTime.Now;
                                             while (DateTime.Now - start < TimeSpan.FromSeconds(1))

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -115,9 +115,9 @@ namespace YeelightAPI
                             {
                                 for (int cpt = 0; cpt < 3; cpt++)
                                 {
-                                    Task<List<Device>> t = Task.Factory.StartNew<List<Device>>(() =>
+                                    foreach (var multicastEndpoint in netInterface.GetIPProperties().MulticastAddresses.Where(x => x.Address.AddressFamily == AddressFamily.InterNetwork).ToList())
                                     {
-                                        foreach (var multicastEndpoint in netInterface.GetIPProperties().MulticastAddresses.Where(x => x.Address.AddressFamily == AddressFamily.InterNetwork).ToList()) 
+                                        Task<List<Device>> t = Task.Factory.StartNew<List<Device>>(() =>
                                         {
                                             Socket ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
                                             {
@@ -157,11 +157,10 @@ namespace YeelightAPI
                                                 }
                                                 Thread.Sleep(10);
                                             }
-                                        }
-
-                                        return devices.Values.ToList();
-                                    });
-                                    tasks.Add(t);
+                                            return devices.Values.ToList();
+                                        });
+                                        tasks.Add(t);
+                                    }
                                 }
                             }
                         }

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -21,10 +21,9 @@ namespace YeelightAPI
     {
         #region Private Fields
 
-        private const string _ssdpMessage = "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1982\r\nMAN: \"ssdp:discover\"\r\nST: wifi_bulb";
+        private const string _ssdpMessageTemplate = "M-SEARCH * HTTP/1.1\r\nHOST: {0}:1982\r\nMAN: \"ssdp:discover\"\r\nST: wifi_bulb";
         private static readonly List<object> _allPropertyRealNames = PROPERTIES.ALL.GetRealNames();
         private static readonly char[] _colon = new char[] { ':' };
-        private static readonly byte[] _ssdpDiagram = Encoding.ASCII.GetBytes(_ssdpMessage);
         private static string _yeelightlocationMatch = "Location: yeelight://";
 
         #endregion Private Fields
@@ -103,8 +102,9 @@ namespace YeelightAPI
 
             try
             {
-                GatewayIPAddressInformation addr = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
                 var ipProperties = netInterface.GetIPProperties();
+                GatewayIPAddressInformation addr = ipProperties.GatewayAddresses.FirstOrDefault();
+                var interfaceIndex = ipProperties.GetIPv4Properties().Index;
                 if (addr != null && !addr.Address.ToString().Equals("0.0.0.0"))
                 {
                     if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 || netInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet)


### PR DESCRIPTION
I wasn't able to discover Yeelight devices on my network, because the multicast address 239.255.255.250 did not work. Instead, 224.0.0.251 did, so I think looping through all IPv4 multicast addresses of an interface during discovery should avoid similar issues in the future.