### PR TITLE
Refactoring DeviceLocator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,16 +144,16 @@ Create instance of [`Progress<T>`](https://docs.microsoft.com/en-us/dotnet/api/s
 When DeviceLocator.DiscoverAsync(Progress<T>) finds a device, the `Progress<T>.Report` method is invoked.
 Example : 
 ```csharp
-	private void OnDeviceFound(Device device) 
-	{
-	  // Do Something with the discovered device   
-	}
+private void OnDeviceFound(Device device) 
+{
+  // Do Something with the discovered device   
+}
 	
-	private	async Task GetDevicesAsync()
-	{
-	  var progressReporter = new Progress<Device>(OnDeviceFound);
-	  List<Devices> discoveredDevices = await DeviceLocator.DiscoverAsync(progresReporter);
-	}
+private	async Task GetDevicesAsync()
+{
+  var progressReporter = new Progress<Device>(OnDeviceFound);
+  List<Devices> discoveredDevices = await DeviceLocator.DiscoverAsync(progresReporter);
+}
 ```
 
 ## VNext

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ example :
 ```
 
 ### Find devices
-If you want to find what devices are connected, you can use `YeelightAPI.DeviceLocator` to find them : 
+If you want to find what devices are connected, you can use `YeelightAPI.DeviceLocator` to find them: 
 ```csharp
-	List<Device> devices = await DeviceLocator.Discover();
+	List<Device> discoveredDevices = await DeviceLocator.DiscoverAsync();
 ```
 
 ### Async / Await
@@ -139,13 +139,21 @@ Example :
 ```
 
 ### Device Found
-When DeviceLocator.Discover() finds a device, the event "DeviceFound" is thrown.
+If you don't want to wait until all devices are discovered, you can make use of the [`IProgress<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.iprogress-1?view=netframework-4.7), to receive intermediate results.
+Create instance of [`Progress<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.progress-1?view=netframework-4.7) and pass to the appropriate DiscoverAsync overload. The callback will always execute oin the caller thread.
+When DeviceLocator.DiscoverAsync(Progress<T>) finds a device, the `Progress<T>.Report` method is invoked.
 Example : 
 ```csharp
-   DeviceLocator.DeviceFound += (object sender, DeviceFoundEventArgs e) =>
-   {
-       Console.WriteLine($"A device has been found : {e.Device}");
-   };
+	private void OnDeviceFound(Device device) 
+	{
+	  // Do Something with the discovered device   
+	}
+	
+	private	async Task GetDevicesAsync()
+	{
+	  var progressReporter = new Progress<Device>(OnDeviceFound);
+	  List<Devices> discoveredDevices = await DeviceLocator.DiscoverAsync(progresReporter);
+	}
 ```
 
 ## VNext

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ All the parameters are defined in the doc ["Yeelight WiFi Light Inter-Operation 
 If you need to control multiple devices at a time, you can use the `YeelightAPI.DeviceGroup` class. 
 This class simply ihnerits from native .net `List<Device>` and implements the `IDeviceController` interface, allowing you to control multiple devices the exact same way you control a single device.
 ```csharp
-	DeviceGroup group = new DeviceGroup();
-	group.Add(device1);
-	group.Add(device2);
+DeviceGroup group = new DeviceGroup();
+group.Add(device1);
+group.Add(device2);
 
-	group.Connect();
-	group.Toggle();
-	...
+group.Connect();
+group.Toggle();
+...
 ```
 
 ### Color Flow
@@ -55,18 +55,19 @@ This class simply ihnerits from native .net `List<Device>` and implements the `I
 You can create a Color Flow to "program" your device with different state changes. Changes can be : RGB color, color temperature and brightness.
 Just create a `new ColorFlow()`, add some `new ColorFlowExpression()` to it, and starts the color flow with your ColorFlow object.
 ```csharp
-    	ColorFlow flow = new ColorFlow(0, ColorFlowEndAction.Restore);
-    	flow.Add(new ColorFlowRGBExpression(255, 0, 0, 1, 500)); // color : red / brightness : 1% / duration : 500
-    	flow.Add(new ColorFlowRGBExpression(0, 255, 0, 100, 500)); // color : green / brightness : 100% / duration : 500
-    	flow.Add(new ColorFlowRGBExpression(0, 0, 255, 50, 500)); // color : blue / brightness : 50% / duration : 500
-    	flow.Add(new ColorFlowSleepExpression(2000)); // sleeps for 2 seconds
-    	flow.Add(new ColorFlowTemperatureExpression(2700, 100, 500)); // color temperature : 2700k / brightness : 100 / duration : 500
-    	flow.Add(new ColorFlowTemperatureExpression(5000, 1, 500)); // color temperature : 5000k / brightness : 100 / duration : 500
-    	device.StartColorFlow(flow); // start
+ColorFlow flow = new ColorFlow(0, ColorFlowEndAction.Restore);
+flow.Add(new ColorFlowRGBExpression(255, 0, 0, 1, 500)); // color : red / brightness : 1% / duration : 500
+flow.Add(new ColorFlowRGBExpression(0, 255, 0, 100, 500)); // color : green / brightness : 100% / duration : 500
+flow.Add(new ColorFlowRGBExpression(0, 0, 255, 50, 500)); // color : blue / brightness : 50% / duration : 500
+flow.Add(new ColorFlowSleepExpression(2000)); // sleeps for 2 seconds
+flow.Add(new ColorFlowTemperatureExpression(2700, 100, 500)); // color temperature : 2700k / brightness : 100 / duration : 500
+flow.Add(new ColorFlowTemperatureExpression(5000, 1, 500)); // color temperature : 5000k / brightness : 100 / duration : 500
 
-	/* Do Some amazing stuff ... */
+device.StartColorFlow(flow); // start
 
-	device.StopColorFlow(); // stop the color flow
+/* Do Some amazing stuff ... */
+
+device.StopColorFlow(); // stop the color flow
 ```
 
 The `ColorFlow` constructor has 2 parameters : the first one defines the number of repetitions (or 0 for infinite), the second one defines what to do when the flow is stopped. you can choose to restore to the previous state, keep the last state or turn off the device.
@@ -75,46 +76,46 @@ The `ColorFlow` constructor has 2 parameters : the first one defines the number 
 Another way to create color flow is to use the `device.Flow()` method. This method returns a `FluentFLow` object you can use to create a flow in a "Fluent-syntax" way.
 example : 
 ```csharp
-	FluentFlow flow = await backgroundDevice.BackgroundFlow()
-                        .RgbColor(255, 0, 0, 50, 1000)
-                        .Sleep(2000)
-                        .RgbColor(0, 255, 0, 50) //without timing
-                        .During(1000) // set the timing of the previous instruction
-                        .Sleep(2000)
-                        .RgbColor(0, 0, 255, 50, 1000)
-                        .Sleep(2000)
-                        .Temperature(2700, 100, 1000)
-                        .Sleep(2000)
-                        .Temperature(6500, 100, 1000)
-                        .Play(ColorFlowEndAction.Keep);
+FluentFlow flow = await backgroundDevice.BackgroundFlow()
+  .RgbColor(255, 0, 0, 50, 1000)
+  .Sleep(2000)
+  .RgbColor(0, 255, 0, 50) //without timing
+  .During(1000) // set the timing of the previous instruction
+  .Sleep(2000)
+  .RgbColor(0, 0, 255, 50, 1000)
+  .Sleep(2000)
+  .Temperature(2700, 100, 1000)
+  .Sleep(2000)
+  .Temperature(6500, 100, 1000)
+  .Play(ColorFlowEndAction.Keep);
 
-	await flow.StopAfter(5000);
+await flow.StopAfter(5000);
 
-	//use the same object to create a new flow
-	await flow.Reset()
-		.RgbColor(0, 255, 0, 50, 1000)
-		.Temperature(3000, 100, 1000)
-		.Play(ColorFlowEndAction.Keep);
+//use the same object to create a new flow
+await flow.Reset()
+  .RgbColor(0, 255, 0, 50, 1000)
+  .Temperature(3000, 100, 1000)
+  .Play(ColorFlowEndAction.Keep);
 ```
 
 ### Find devices
 If you want to find what devices are connected, you can use `YeelightAPI.DeviceLocator` to find them: 
 ```csharp
-	List<Device> discoveredDevices = await DeviceLocator.DiscoverAsync();
+List<Device> discoveredDevices = await DeviceLocator.DiscoverAsync();
 ```
 
 ### Async / Await
 Almost every methods are asynchronous and are awaitable tasks. you can either call them with await, or wait the result : 
 Example : 
 ```csharp
-	// with single device
-	await device.Connect();
-	device.Toggle().Result;
+// with single device
+await device.Connect();
+device.Toggle().Result;
 
-	//with groups
-	group.Connect().Result;
-	await group.Toggle();
-	...
+//with groups
+group.Connect().Result;
+await group.Toggle();
+...
 ```
 
 ## Events
@@ -122,20 +123,20 @@ Example :
 When you call a method that changes the state of the device, it sends a notification to inform that its state really change. You can receive these notification using the "OnNotificationReceived" event.
 Example : 
 ```csharp
-   device.OnNotificationReceived += (object sender, NotificationReceivedEventArgs arg) =>
-   {
-       Console.WriteLine("Notification received !! value : " + JsonConvert.SerializeObject(arg.Result));
-   };
+device.OnNotificationReceived += (object sender, NotificationReceivedEventArgs arg) =>
+{
+  Console.WriteLine("Notification received !! value : " + JsonConvert.SerializeObject(arg.Result));
+};
 ```
 
 ### Errors
 When an unknown error occurs, a "OnError" event is fired.
 Example : 
 ```csharp
-   device.OnError += (object sender, UnhandledExceptionEventArgs e) =>
-   {
-       Console.WriteLine($"An error occurred : {e.ExceptionObject}");
-   };
+device.OnError += (object sender, UnhandledExceptionEventArgs e) =>
+{
+  Console.WriteLine($"An error occurred : {e.ExceptionObject}");
+};
 ```
 
 ### Device Found

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -264,7 +264,7 @@ namespace YeelightAPI
       return new List<Device>();
     }
 
-    private static List<Device> CheckSocketForDevices(UnicastIPAddressInformation ip, IProgress<Device> deviceFoundCallback)
+    private static IEnumerable<Device> CheckSocketForDevices(UnicastIPAddressInformation ip, IProgress<Device> deviceFoundCallback)
     {
       // Use hash table for faster lookup, than List.Contains
       var devices = new Dictionary<string, Device>();

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -199,21 +199,29 @@ namespace YeelightAPI
                     }
                     catch (SocketException)
                     {
+                      // Continue polling
                     }
 
                     await Task.Delay(TimeSpan.FromMilliseconds(10));
                   }
+
                   stopWatch.Stop();
                 }
               }
-              catch (SocketException)
+              catch (SocketException e)
               {
+                if (cpt >= DeviceLocator.MaxRetryCount - 1)
+                {
+                  // Wrap exception to preserve original stacktrace for re-throw,
+                  // because SocketException doesn't provide a constructor overload to accept inner exception.
+                  throw new InvalidOperationException("Network socket error.", e);
+                }
               }
               finally
               {
                 stopWatch.Stop();
               }
-                    
+
 
               return devices.Values.ToList();
             });

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -25,7 +25,7 @@ namespace YeelightAPI
 
     static DeviceLocator()
     {
-      DeviceLocator.ReadSocketRetryCounter = 3;
+      DeviceLocator.RetryCount = 3;
     }
 
     #endregion
@@ -44,11 +44,11 @@ namespace YeelightAPI
     #endregion Private Fields
 
     /// <summary>
-    /// Retry counter to lookup network sockets for devices.
+    /// Retry count for network sockets lookup to find devices.
     /// </summary> 
-    /// <value>The number of retries. Default is 3.</value>
-    /// <remarks>A single iteration will take a maximum of 1 second. Each iteration will poll in intervals of 10 ms to listen to an IP for devices. This means the value of <see cref="ReadSocketRetryCounter"/> is equivalent to execution time in seconds.</remarks>
-    public static int ReadSocketRetryCounter { get; set; }
+    /// <value>The number of lookup retries. Default is 3.</value>
+    /// <remarks>A single iteration will take a maximum of 1 second. Each iteration will poll in intervals of 10 ms to listen to an IP for devices. This means the value of <see cref="RetryCount"/> is equivalent to execution time in seconds.</remarks>
+    public static int RetryCount { get; set; }
 
     #region Depricated API. TODO: Remove
 
@@ -136,7 +136,7 @@ namespace YeelightAPI
           continue;
         }
 
-        for (var cpt = 0; cpt < DeviceLocator.ReadSocketRetryCounter; cpt++)
+        for (var cpt = 0; cpt < DeviceLocator.RetryCount; cpt++)
         {
           Task<List<Device>> t = Task.Run(
             async () =>
@@ -301,7 +301,7 @@ namespace YeelightAPI
       var stopWatch = new Stopwatch();
       try // Catch socket creation exception
       {
-        for (int retryCounter = 0; retryCounter < DeviceLocator.ReadSocketRetryCounter; retryCounter++)
+        for (int retryCounter = 0; retryCounter < DeviceLocator.RetryCount; retryCounter++)
         {
           using (var ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
           {

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -205,10 +205,9 @@ namespace YeelightAPI
     /// <returns></returns>
     public static async Task<IEnumerable<Device>> DiscoverAsync(IProgress<Device> deviceFoundReporter)
     {
-      List<Task<IEnumerable<Device>>> tasks = NetworkInterface.GetAllNetworkInterfaces()
-        .Where(n => n.OperationalStatus == OperationalStatus.Up)
-        .Select(ni => DeviceLocator.DiscoverAsync(ni, deviceFoundReporter))
-        .ToList();
+      IEnumerable<Task<IEnumerable<Device>>> tasks = NetworkInterface.GetAllNetworkInterfaces()
+        .Where(networkInterface => networkInterface.OperationalStatus == OperationalStatus.Up)
+        .Select(networkInterface => DeviceLocator.DiscoverAsync(networkInterface, deviceFoundReporter));
 
       IEnumerable<Device>[] result = await Task.WhenAll(tasks);
       return result.SelectMany(devices => devices).ToList();

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -17,463 +17,463 @@ using YeelightAPI.Models;
 
 namespace YeelightAPI
 {
-  /// <summary>
-  ///   Finds devices through LAN
-  /// </summary>
-  public static class DeviceLocator
-  {
-    #region Constructors
-
-    static DeviceLocator()
+    /// <summary>
+    ///   Finds devices through LAN
+    /// </summary>
+    public static class DeviceLocator
     {
-      DeviceLocator.MaxRetryCount = 3;
-    }
+        #region Constructors
 
-    #endregion
-
-    #region Private Fields
-
-    private const string _ssdpMessage =
-      "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1982\r\nMAN: \"ssdp:discover\"\r\nST: wifi_bulb";
-
-    private static readonly List<object> _allPropertyRealNames = PROPERTIES.ALL.GetRealNames();
-    private static readonly char[] _colon = {':'};
-    private static readonly IPEndPoint _multicastEndPoint = new IPEndPoint(IPAddress.Parse("239.255.255.250"), 1982);
-    private static readonly byte[] _ssdpDiagram = Encoding.ASCII.GetBytes(DeviceLocator._ssdpMessage);
-    private static readonly string _yeelightlocationMatch = "Location: yeelight://";
-
-    #endregion Private Fields
-
-    /// <summary>
-    /// Retry count for network sockets lookup to find devices.
-    /// </summary> 
-    /// <value>The number of lookup retries. Default is 3.</value>
-    /// <remarks>A single iteration will take a maximum of 1 second. Each iteration will poll in intervals of 10 ms to listen to an IP for devices. This means the value of <see cref="MaxRetryCount"/> is equivalent to execution time in seconds.</remarks>
-    public static int MaxRetryCount { get; set; }
-
-    #region Depricated API. TODO: Remove
-
-    /// <summary>
-    ///   Notification Received event
-    /// </summary>
-    [Obsolete("Deprecated. Event will be removed in next release.")]
-    public static event DeviceFoundEventHandler OnDeviceFound;
-
-    /// <summary>
-    ///   Notification Received event handler
-    /// </summary>
-    /// <param name="sender"></param>
-    /// <param name="e"></param>
-    [Obsolete("Deprecated. Event will be removed in next release.")]
-    public delegate void DeviceFoundEventHandler(object sender, DeviceFoundEventArgs e);
-
-    #region Public Methods
-
-    /// <summary>
-    ///   Discover devices in a specific Network Interface
-    /// </summary>
-    /// <param name="preferredInterface"></param>
-    /// <returns></returns>
-    [Obsolete("Deprecated. Use DiscoverAsync and overloads instead.")]
-    public static async Task<List<Device>> Discover(NetworkInterface preferredInterface)
-    {
-      List<Task<List<Device>>> tasks = DeviceLocator.CreateDiscoverTasks(preferredInterface, DeviceLocator.MaxRetryCount);
-
-      List<Device>[] result = await Task.WhenAll(tasks);
-      return result
-        .SelectMany(devices => devices)
-        .GroupBy(d => d.Hostname)
-        .Select(g => g.First())
-        .ToList();
-    }
-
-    /// <summary>
-    ///   Discover devices in LAN
-    /// </summary>
-    /// <returns></returns>
-    [Obsolete("Deprecated. Use DiscoverAsync and overloads instead.")]
-    public static async Task<List<Device>> Discover()
-    {
-      var tasks = new List<Task<List<Device>>>();
-      int retryCount = DeviceLocator.MaxRetryCount;
-      foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces()
-        .Where(n => n.OperationalStatus == OperationalStatus.Up))
-      {
-        tasks.AddRange(DeviceLocator.CreateDiscoverTasks(ni, retryCount));
-      }
-
-
-      List<Device>[] result = await Task.WhenAll(tasks);
-      return result
-        .SelectMany(devices => devices)
-        .GroupBy(d => d.Hostname)
-        .Select(g => g.First())
-        .ToList();
-    }
-
-    #endregion Public Methods
-
-    #region Private Methods
-
-    /// <summary>
-    ///   Create Discovery tasks for a specific Network Interface
-    /// </summary>
-    /// <param name="netInterface"></param>
-    /// <param name="retryCount">Number of retries when lookup fails.</param>
-    /// <returns></returns>
-    [Obsolete("Deprecated. Use SearchNetworkForDevicesAsync instead")]
-    private static List<Task<List<Device>>> CreateDiscoverTasks(NetworkInterface netInterface, int retryCount)
-    {
-      var devices = new ConcurrentDictionary<string, Device>();
-      var tasks = new List<Task<List<Device>>>();
-      GatewayIPAddressInformation addr = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
-
-      if (addr == null || addr.Address.ToString().Equals("0.0.0.0"))
-      {
-        return tasks;
-      }
-
-      if (netInterface.NetworkInterfaceType != NetworkInterfaceType.Wireless80211 &&
-          netInterface.NetworkInterfaceType != NetworkInterfaceType.Ethernet)
-      {
-        return tasks;
-      }
-
-      foreach (UnicastIPAddressInformation ip in netInterface.GetIPProperties().UnicastAddresses)
-      {
-        if (ip.Address.AddressFamily != AddressFamily.InterNetwork)
+        static DeviceLocator()
         {
-          continue;
+            DeviceLocator.MaxRetryCount = 1;
         }
 
-        for (var count = 0; count < retryCount; count++)
+        #endregion
+
+        #region Private Fields
+
+        private const string _ssdpMessage =
+          "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1982\r\nMAN: \"ssdp:discover\"\r\nST: wifi_bulb";
+
+        private static readonly List<object> _allPropertyRealNames = PROPERTIES.ALL.GetRealNames();
+        private static readonly char[] _colon = { ':' };
+        private static readonly IPEndPoint _multicastEndPoint = new IPEndPoint(IPAddress.Parse("239.255.255.250"), 1982);
+        private static readonly byte[] _ssdpDiagram = Encoding.ASCII.GetBytes(DeviceLocator._ssdpMessage);
+        private static readonly string _yeelightlocationMatch = "Location: yeelight://";
+
+        #endregion Private Fields
+
+        /// <summary>
+        /// Retry count for network sockets lookup to find devices.
+        /// </summary> 
+        /// <value>The number of lookup retries. Default is 3.</value>
+        /// <remarks>A single iteration will take a maximum of 1 second. Each iteration will poll in intervals of 10 ms to listen to an IP for devices. This means the value of <see cref="MaxRetryCount"/> is equivalent to execution time in seconds.</remarks>
+        public static int MaxRetryCount { get; set; }
+
+        #region Depricated API. TODO: Remove
+
+        /// <summary>
+        ///   Notification Received event
+        /// </summary>
+        [Obsolete("Deprecated. Event will be removed in next release.")]
+        public static event DeviceFoundEventHandler OnDeviceFound;
+
+        /// <summary>
+        ///   Notification Received event handler
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        [Obsolete("Deprecated. Event will be removed in next release.")]
+        public delegate void DeviceFoundEventHandler(object sender, DeviceFoundEventArgs e);
+
+        #region Public Methods
+
+        /// <summary>
+        ///   Discover devices in a specific Network Interface
+        /// </summary>
+        /// <param name="preferredInterface"></param>
+        /// <returns></returns>
+        [Obsolete("Deprecated. Use DiscoverAsync and overloads instead.")]
+        public static async Task<List<Device>> Discover(NetworkInterface preferredInterface)
         {
-          Task<List<Device>> t = Task.Run(
-            async () =>
+            List<Task<List<Device>>> tasks = DeviceLocator.CreateDiscoverTasks(preferredInterface, DeviceLocator.MaxRetryCount);
+
+            List<Device>[] result = await Task.WhenAll(tasks);
+            return result
+              .SelectMany(devices => devices)
+              .GroupBy(d => d.Hostname)
+              .Select(g => g.First())
+              .ToList();
+        }
+
+        /// <summary>
+        ///   Discover devices in LAN
+        /// </summary>
+        /// <returns></returns>
+        [Obsolete("Deprecated. Use DiscoverAsync and overloads instead.")]
+        public static async Task<List<Device>> Discover()
+        {
+            var tasks = new List<Task<List<Device>>>();
+            int retryCount = DeviceLocator.MaxRetryCount;
+            foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces()
+              .Where(n => n.OperationalStatus == OperationalStatus.Up))
             {
-              var stopWatch = new Stopwatch();
-              try
-              {
-                using (var ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+                tasks.AddRange(DeviceLocator.CreateDiscoverTasks(ni, retryCount));
+            }
+
+
+            List<Device>[] result = await Task.WhenAll(tasks);
+            return result
+              .SelectMany(devices => devices)
+              .GroupBy(d => d.Hostname)
+              .Select(g => g.First())
+              .ToList();
+        }
+
+        #endregion Public Methods
+
+        #region Private Methods
+
+        /// <summary>
+        ///   Create Discovery tasks for a specific Network Interface
+        /// </summary>
+        /// <param name="netInterface"></param>
+        /// <param name="retryCount">Number of retries when lookup fails.</param>
+        /// <returns></returns>
+        [Obsolete("Deprecated. Use SearchNetworkForDevicesAsync instead")]
+        private static List<Task<List<Device>>> CreateDiscoverTasks(NetworkInterface netInterface, int retryCount)
+        {
+            var devices = new ConcurrentDictionary<string, Device>();
+            var tasks = new List<Task<List<Device>>>();
+            GatewayIPAddressInformation addr = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
+
+            if (addr == null || addr.Address.ToString().Equals("0.0.0.0"))
+            {
+                return tasks;
+            }
+
+            if (netInterface.NetworkInterfaceType != NetworkInterfaceType.Wireless80211 &&
+                netInterface.NetworkInterfaceType != NetworkInterfaceType.Ethernet)
+            {
+                return tasks;
+            }
+
+            foreach (UnicastIPAddressInformation ip in netInterface.GetIPProperties().UnicastAddresses)
+            {
+                if (ip.Address.AddressFamily != AddressFamily.InterNetwork)
                 {
-                  Blocking = false,
-                  Ttl = 1,
-                  UseOnlyOverlappedIO = true,
-                  MulticastLoopback = false
-                })
+                    continue;
+                }
+
+                for (var count = 0; count < retryCount; count++)
                 {
-                  ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
-                  ssdpSocket.SetSocketOption(
-                    SocketOptionLevel.IP,
-                    SocketOptionName.AddMembership,
-                    new MulticastOption(DeviceLocator._multicastEndPoint.Address));
-
-                  ssdpSocket.SendTo(
-                    DeviceLocator._ssdpDiagram,
-                    SocketFlags.None,
-                    DeviceLocator._multicastEndPoint);
-
-                  stopWatch.Start();
-                  while (stopWatch.Elapsed < TimeSpan.FromSeconds(1))
-                  {
-                    try
-                    {
-                      int available = ssdpSocket.Available;
-
-                      if (available > 0)
+                    Task<List<Device>> t = Task.Run(
+                      async () =>
                       {
-                        var buffer = new byte[available];
-                        int i = ssdpSocket.Receive(buffer, SocketFlags.None);
-
-                        if (i > 0)
-                        {
-                          string response = Encoding.UTF8.GetString(buffer.Take(i).ToArray());
-                          Device device = DeviceLocator.GetDeviceInformationFromSsdpMessage(response);
-
-                          //add only if no device already matching
-                          if (devices.TryAdd(device.Hostname, device))
+                          var stopWatch = new Stopwatch();
+                          try
                           {
-                            DeviceLocator.OnDeviceFound?.Invoke(null, new DeviceFoundEventArgs(device));
+                              using (var ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+                              {
+                                  Blocking = false,
+                                  Ttl = 1,
+                                  UseOnlyOverlappedIO = true,
+                                  MulticastLoopback = false
+                              })
+                              {
+                                  ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
+                                  ssdpSocket.SetSocketOption(
+                          SocketOptionLevel.IP,
+                          SocketOptionName.AddMembership,
+                          new MulticastOption(DeviceLocator._multicastEndPoint.Address));
+
+                                  ssdpSocket.SendTo(
+                          DeviceLocator._ssdpDiagram,
+                          SocketFlags.None,
+                          DeviceLocator._multicastEndPoint);
+
+                                  stopWatch.Start();
+                                  while (stopWatch.Elapsed < TimeSpan.FromSeconds(1))
+                                  {
+                                      try
+                                      {
+                                          int available = ssdpSocket.Available;
+
+                                          if (available > 0)
+                                          {
+                                              var buffer = new byte[available];
+                                              int i = ssdpSocket.Receive(buffer, SocketFlags.None);
+
+                                              if (i > 0)
+                                              {
+                                                  string response = Encoding.UTF8.GetString(buffer.Take(i).ToArray());
+                                                  Device device = DeviceLocator.GetDeviceInformationFromSsdpMessage(response);
+
+                                        //add only if no device already matching
+                                        if (devices.TryAdd(device.Hostname, device))
+                                                  {
+                                                      DeviceLocator.OnDeviceFound?.Invoke(null, new DeviceFoundEventArgs(device));
+                                                  }
+                                              }
+                                          }
+                                      }
+                                      catch (SocketException)
+                                      {
+                                // Continue polling
+                            }
+
+                                      await Task.Delay(TimeSpan.FromMilliseconds(10));
+                                  }
+
+                                  stopWatch.Stop();
+                              }
                           }
+                          catch (SocketException)
+                          {
+                              return devices.Values.ToList();
+                          }
+                          finally
+                          {
+                              stopWatch.Stop();
+                          }
+
+                          return devices.Values.ToList();
+                      });
+
+                    tasks.Add(t);
+                }
+            }
+
+            return tasks;
+        }
+
+        #endregion Depricated API. TODO: Remove
+
+        #endregion Depricated API. TODO: Remove
+
+        #region Async API Methods
+
+        /// <summary>
+        ///   Discover devices in LAN
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<IEnumerable<Device>> DiscoverAsync() =>
+          await DeviceLocator.DiscoverAsync(deviceFoundReporter: null);
+
+        /// <summary>
+        ///   Discover devices in LAN
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<IEnumerable<Device>> DiscoverAsync(IProgress<Device> deviceFoundReporter)
+        {
+            IEnumerable<Task<IEnumerable<Device>>> tasks = NetworkInterface.GetAllNetworkInterfaces()
+              .Where(networkInterface => networkInterface.OperationalStatus == OperationalStatus.Up)
+              .Select(networkInterface => DeviceLocator.DiscoverAsync(networkInterface, deviceFoundReporter));
+
+            IEnumerable<Device>[] result = await Task.WhenAll(tasks);
+            return result
+              .SelectMany(devices => devices)
+              .GroupBy(d => d.Hostname)
+              .Select(g => g.First())
+              .ToList();
+        }
+
+        /// <summary>
+        ///   Discover devices in a specific Network Interface
+        /// </summary>
+        /// <param name="networkInterface"></param>
+        /// <returns></returns>
+        public static async Task<IEnumerable<Device>> DiscoverAsync(NetworkInterface networkInterface) =>
+          await DeviceLocator.DiscoverAsync(networkInterface, null);
+
+        /// <summary>
+        ///   Discover devices in a specific Network Interface
+        /// </summary>
+        /// <param name="networkInterface"></param>
+        /// <param name="deviceFoundReporter"></param>
+        /// <returns></returns>
+        public static async Task<IEnumerable<Device>> DiscoverAsync(
+          NetworkInterface networkInterface,
+          IProgress<Device> deviceFoundReporter) =>
+          await DeviceLocator.SearchNetworkForDevicesAsync(networkInterface, deviceFoundReporter);
+
+        #endregion Async API Methods
+
+
+        /// <summary>
+        ///   Create Discovery tasks for a specific Network Interface
+        /// </summary>
+        /// <param name="netInterface"></param>
+        /// <param name="deviceFoundCallback"></param>
+        /// <returns></returns>
+        private static async Task<IEnumerable<Device>> SearchNetworkForDevicesAsync(NetworkInterface netInterface, IProgress<Device> deviceFoundCallback)
+        {
+            GatewayIPAddressInformation addressInformation = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
+
+            if (addressInformation == null || addressInformation.Address.ToString().Equals("0.0.0.0"))
+            {
+                return new List<Device>();
+            }
+
+            if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 ||
+                netInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+            {
+                int retryCount = DeviceLocator.MaxRetryCount;
+                return await Task.Run(
+                  () => netInterface.GetIPProperties().UnicastAddresses
+                    .Where(ip => ip.Address.AddressFamily == AddressFamily.InterNetwork)
+                    .AsParallel()
+                    .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
+                    .SelectMany(ip => DeviceLocator.CheckSocketForDevices(ip, deviceFoundCallback, retryCount))
+                    .ToList());
+            }
+
+            return new List<Device>();
+        }
+
+        private static IEnumerable<Device> CheckSocketForDevices(UnicastIPAddressInformation ip, IProgress<Device> deviceFoundCallback, int retryCount)
+        {
+            // Use hash table for faster lookup, than List.Contains
+            var devices = new Dictionary<string, Device>();
+
+            for (int count = 0; count < retryCount; count++)
+            {
+                try
+                {
+                    using (var ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+                    {
+                        DeviceLocator.InitializeSocket(ip, ssdpSocket);
+                        DeviceLocator.GetDevicesFromSocket(deviceFoundCallback, ssdpSocket, devices);
+                    }
+                }
+                catch (SocketException)
+                {
+                    return devices.Values.ToList();
+                }
+            }
+
+            return devices.Values.ToList();
+        }
+
+        private static void InitializeSocket(UnicastIPAddressInformation ip, Socket ssdpSocket)
+        {
+            ssdpSocket.Blocking = false;
+            ssdpSocket.Ttl = 1;
+            ssdpSocket.UseOnlyOverlappedIO = true;
+            ssdpSocket.MulticastLoopback = false;
+            ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
+            ssdpSocket.SetSocketOption(
+              SocketOptionLevel.IP,
+              SocketOptionName.AddMembership,
+              new MulticastOption(DeviceLocator._multicastEndPoint.Address));
+        }
+
+        private static void GetDevicesFromSocket(IProgress<Device> deviceFoundCallback, Socket ssdpSocket, Dictionary<string, Device> devices)
+        {
+            ssdpSocket.SendTo(DeviceLocator._ssdpDiagram, SocketFlags.None, DeviceLocator._multicastEndPoint);
+
+            var stopWatch = Stopwatch.StartNew();
+            try
+            {
+                while (stopWatch.Elapsed < TimeSpan.FromSeconds(1))
+                {
+                    try // Catch socket read exception
+                    {
+                        int available = ssdpSocket.Available;
+
+                        if (available > 0)
+                        {
+                            var buffer = new byte[available];
+                            int numberOfBytesRead = ssdpSocket.Receive(buffer, SocketFlags.None);
+
+                            if (numberOfBytesRead > 0)
+                            {
+                                string response = Encoding.UTF8.GetString(buffer.Take(numberOfBytesRead).ToArray());
+                                Device device = DeviceLocator.GetDeviceInformationFromSsdpMessage(response);
+
+                                if (!devices.ContainsKey(device.Hostname))
+                                {
+                                    devices.Add(device.Hostname, device);
+                                    deviceFoundCallback?.Report(device);
+                                }
+                            }
                         }
-                      }
                     }
                     catch (SocketException)
                     {
-                      // Continue polling
+                        // Ignore SocketException and continue polling
                     }
 
-                    await Task.Delay(TimeSpan.FromMilliseconds(10));
-                  }
-
-                  stopWatch.Stop();
+                    Thread.Sleep(TimeSpan.FromMilliseconds(10));
                 }
-              }
-              catch (SocketException)
-              {
-                return devices.Values.ToList();
-              }
-              finally
-              {
+            }
+            finally
+            {
                 stopWatch.Stop();
-              }
-
-              return devices.Values.ToList();
-            });
-
-          tasks.Add(t);
+            }
         }
-      }
 
-      return tasks;
-    }
-
-    #endregion Depricated API. TODO: Remove
-
-    #endregion Depricated API. TODO: Remove
-
-    #region Async API Methods
-
-    /// <summary>
-    ///   Discover devices in LAN
-    /// </summary>
-    /// <returns></returns>
-    public static async Task<IEnumerable<Device>> DiscoverAsync() =>
-      await DeviceLocator.DiscoverAsync(deviceFoundReporter: null);
-
-    /// <summary>
-    ///   Discover devices in LAN
-    /// </summary>
-    /// <returns></returns>
-    public static async Task<IEnumerable<Device>> DiscoverAsync(IProgress<Device> deviceFoundReporter)
-    {
-      IEnumerable<Task<IEnumerable<Device>>> tasks = NetworkInterface.GetAllNetworkInterfaces()
-        .Where(networkInterface => networkInterface.OperationalStatus == OperationalStatus.Up)
-        .Select(networkInterface => DeviceLocator.DiscoverAsync(networkInterface, deviceFoundReporter));
-
-      IEnumerable<Device>[] result = await Task.WhenAll(tasks);
-      return result
-        .SelectMany(devices => devices)
-        .GroupBy(d => d.Hostname)
-        .Select(g => g.First())
-        .ToList();
-    }
-
-    /// <summary>
-    ///   Discover devices in a specific Network Interface
-    /// </summary>
-    /// <param name="networkInterface"></param>
-    /// <returns></returns>
-    public static async Task<IEnumerable<Device>> DiscoverAsync(NetworkInterface networkInterface) =>
-      await DeviceLocator.DiscoverAsync(networkInterface, null);
-
-    /// <summary>
-    ///   Discover devices in a specific Network Interface
-    /// </summary>
-    /// <param name="networkInterface"></param>
-    /// <param name="deviceFoundReporter"></param>
-    /// <returns></returns>
-    public static async Task<IEnumerable<Device>> DiscoverAsync(
-      NetworkInterface networkInterface,
-      IProgress<Device> deviceFoundReporter) =>
-      await DeviceLocator.SearchNetworkForDevicesAsync(networkInterface, deviceFoundReporter);
-
-    #endregion Async API Methods
-
-
-    /// <summary>
-    ///   Create Discovery tasks for a specific Network Interface
-    /// </summary>
-    /// <param name="netInterface"></param>
-    /// <param name="deviceFoundCallback"></param>
-    /// <returns></returns>
-    private static async Task<IEnumerable<Device>> SearchNetworkForDevicesAsync(NetworkInterface netInterface, IProgress<Device> deviceFoundCallback)
-    {
-      GatewayIPAddressInformation addressInformation = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
-
-      if (addressInformation == null || addressInformation.Address.ToString().Equals("0.0.0.0"))
-      {
-        return new List<Device>();
-      }
-
-      if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 ||
-          netInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
-      {
-        int retryCount = DeviceLocator.MaxRetryCount;
-        return await Task.Run(
-          () => netInterface.GetIPProperties().UnicastAddresses
-            .Where(ip => ip.Address.AddressFamily == AddressFamily.InterNetwork)
-            .AsParallel()
-            .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
-            .SelectMany(ip => DeviceLocator.CheckSocketForDevices(ip, deviceFoundCallback, retryCount))
-            .ToList());
-      }
-
-      return new List<Device>();
-    }
-
-    private static IEnumerable<Device> CheckSocketForDevices(UnicastIPAddressInformation ip, IProgress<Device> deviceFoundCallback, int retryCount)
-    {
-      // Use hash table for faster lookup, than List.Contains
-      var devices = new Dictionary<string, Device>();
-
-      for (int count = 0; count < retryCount; count++)
-      {
-        try 
+        /// <summary>
+        ///   Gets the informations from a raw SSDP message (host, port)
+        /// </summary>
+        /// <param name="ssdpMessage"></param>
+        /// <returns></returns>
+        private static Device GetDeviceInformationFromSsdpMessage(string ssdpMessage)
         {
-          using (var ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
-          {
-            DeviceLocator.InitializeSocket(ip, ssdpSocket);
-            DeviceLocator.GetDevicesFromSocket(deviceFoundCallback, ssdpSocket, devices);
-          }
-        }
-        catch (SocketException)
-        {
-          return devices.Values.ToList();
-        }
-      }
-
-      return devices.Values.ToList();
-    }
-
-    private static void InitializeSocket(UnicastIPAddressInformation ip, Socket ssdpSocket)
-    {
-      ssdpSocket.Blocking = false;
-      ssdpSocket.Ttl = 1;
-      ssdpSocket.UseOnlyOverlappedIO = true;
-      ssdpSocket.MulticastLoopback = false;
-      ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
-      ssdpSocket.SetSocketOption(
-        SocketOptionLevel.IP,
-        SocketOptionName.AddMembership,
-        new MulticastOption(DeviceLocator._multicastEndPoint.Address));
-    }
-
-    private static void GetDevicesFromSocket(IProgress<Device> deviceFoundCallback, Socket ssdpSocket, Dictionary<string, Device> devices)
-    {
-      ssdpSocket.SendTo( DeviceLocator._ssdpDiagram, SocketFlags.None, DeviceLocator._multicastEndPoint);
-
-      var stopWatch = Stopwatch.StartNew();
-      try
-      {
-        while (stopWatch.Elapsed < TimeSpan.FromSeconds(1))
-        {
-          try // Catch socket read exception
-          {
-            int available = ssdpSocket.Available;
-
-            if (available > 0)
+            if (ssdpMessage != null)
             {
-              var buffer = new byte[available];
-              int numberOfBytesRead = ssdpSocket.Receive(buffer, SocketFlags.None);
+                string[] split = ssdpMessage.Split(new[] { Constants.LineSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                string host = null;
+                int port = Constants.DefaultPort;
+                var properties = new Dictionary<string, object>();
+                var supportedMethods = new List<METHODS>();
+                string id = null, firmwareVersion = null;
+                MODEL model = default;
 
-              if (numberOfBytesRead > 0)
-              {
-                string response = Encoding.UTF8.GetString(buffer.Take(numberOfBytesRead).ToArray());
-                Device device = DeviceLocator.GetDeviceInformationFromSsdpMessage(response);
-
-                if (!devices.ContainsKey(device.Hostname))
+                foreach (string part in split)
                 {
-                  devices.Add(device.Hostname, device);
-                  deviceFoundCallback?.Report(device);
-                }
-              }
-            }
-          }
-          catch (SocketException)
-          {
-            // Ignore SocketException and continue polling
-          }
+                    if (part.StartsWith(DeviceLocator._yeelightlocationMatch))
+                    {
+                        string url = part.Substring(DeviceLocator._yeelightlocationMatch.Length);
+                        string[] hostnameParts = url.Split(DeviceLocator._colon, StringSplitOptions.RemoveEmptyEntries);
+                        if (hostnameParts.Length >= 1)
+                        {
+                            host = hostnameParts[0];
+                        }
 
-          Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                        if (hostnameParts.Length == 2)
+                        {
+                            int.TryParse(hostnameParts[1], out port);
+                        }
+                    }
+                    else
+                    {
+                        string[] property = part.Split(DeviceLocator._colon);
+                        if (property.Length == 2)
+                        {
+                            string propertyName = property[0].Trim();
+                            string propertyValue = property[1].Trim();
+
+                            if (DeviceLocator._allPropertyRealNames.Contains(propertyName))
+                            {
+                                properties.Add(propertyName, propertyValue);
+                            }
+                            else if (propertyName == "id")
+                            {
+                                id = propertyValue;
+                            }
+                            else if (propertyName == "model")
+                            {
+                                if (!RealNameAttributeExtension.TryParseByRealName(propertyValue, out model))
+                                {
+                                    model = default;
+                                }
+                            }
+                            else if (propertyName == "support")
+                            {
+                                string[] supportedOperations = propertyValue.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                                foreach (string operation in supportedOperations)
+                                {
+                                    if (RealNameAttributeExtension.TryParseByRealName(operation, out METHODS method))
+                                    {
+                                        supportedMethods.Add(method);
+                                    }
+                                }
+                            }
+                            else if (propertyName == "fw_ver")
+                            {
+                                firmwareVersion = propertyValue;
+                            }
+                        }
+                    }
+                }
+
+                return new Device(host, port, id, model, firmwareVersion, properties, supportedMethods);
+            }
+
+            return null;
         }
-      }
-      finally
-      {
-        stopWatch.Stop();
-      }
     }
-
-    /// <summary>
-    ///   Gets the informations from a raw SSDP message (host, port)
-    /// </summary>
-    /// <param name="ssdpMessage"></param>
-    /// <returns></returns>
-    private static Device GetDeviceInformationFromSsdpMessage(string ssdpMessage)
-    {
-      if (ssdpMessage != null)
-      {
-        string[] split = ssdpMessage.Split(new[] {Constants.LineSeparator}, StringSplitOptions.RemoveEmptyEntries);
-        string host = null;
-        int port = Constants.DefaultPort;
-        var properties = new Dictionary<string, object>();
-        var supportedMethods = new List<METHODS>();
-        string id = null, firmwareVersion = null;
-        MODEL model = default;
-
-        foreach (string part in split)
-        {
-          if (part.StartsWith(DeviceLocator._yeelightlocationMatch))
-          {
-            string url = part.Substring(DeviceLocator._yeelightlocationMatch.Length);
-            string[] hostnameParts = url.Split(DeviceLocator._colon, StringSplitOptions.RemoveEmptyEntries);
-            if (hostnameParts.Length >= 1)
-            {
-              host = hostnameParts[0];
-            }
-
-            if (hostnameParts.Length == 2)
-            {
-              int.TryParse(hostnameParts[1], out port);
-            }
-          }
-          else
-          {
-            string[] property = part.Split(DeviceLocator._colon);
-            if (property.Length == 2)
-            {
-              string propertyName = property[0].Trim();
-              string propertyValue = property[1].Trim();
-
-              if (DeviceLocator._allPropertyRealNames.Contains(propertyName))
-              {
-                properties.Add(propertyName, propertyValue);
-              }
-              else if (propertyName == "id")
-              {
-                id = propertyValue;
-              }
-              else if (propertyName == "model")
-              {
-                if (!RealNameAttributeExtension.TryParseByRealName(propertyValue, out model))
-                {
-                  model = default;
-                }
-              }
-              else if (propertyName == "support")
-              {
-                string[] supportedOperations = propertyValue.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
-
-                foreach (string operation in supportedOperations)
-                {
-                  if (RealNameAttributeExtension.TryParseByRealName(operation, out METHODS method))
-                  {
-                    supportedMethods.Add(method);
-                  }
-                }
-              }
-              else if (propertyName == "fw_ver")
-              {
-                firmwareVersion = propertyValue;
-              }
-            }
-          }
-        }
-
-        return new Device(host, port, id, model, firmwareVersion, properties, supportedMethods);
-      }
-
-      return null;
-    }
-  }
 }

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -188,7 +188,7 @@ namespace YeelightAPI
                         if (i > 0)
                         {
                           string response = Encoding.UTF8.GetString(buffer.Take(i).ToArray());
-                          Device device = DeviceLocator.GetDeviceInformationsFromSsdpMessage(response);
+                          Device device = DeviceLocator.GetDeviceInformationFromSsdpMessage(response);
 
                           //add only if no device already matching
                           if (devices.TryAdd(device.Hostname, device))
@@ -230,8 +230,9 @@ namespace YeelightAPI
 
     #endregion Depricated API. TODO: Remove
 
+    #endregion Depricated API. TODO: Remove
 
-    #region Public Methods
+    #region Async API Methods
 
     /// <summary>
     ///   Discover devices in LAN
@@ -277,7 +278,8 @@ namespace YeelightAPI
       IProgress<Device> deviceFoundReporter) =>
       await DeviceLocator.SearchNetworkForDevicesAsync(networkInterface, deviceFoundReporter);
 
-    #endregion Public Methods
+    #endregion Async API Methods
+
 
     /// <summary>
     ///   Create Discovery tasks for a specific Network Interface
@@ -368,7 +370,7 @@ namespace YeelightAPI
               if (numberOfBytesRead > 0)
               {
                 string response = Encoding.UTF8.GetString(buffer.Take(numberOfBytesRead).ToArray());
-                Device device = DeviceLocator.GetDeviceInformationsFromSsdpMessage(response);
+                Device device = DeviceLocator.GetDeviceInformationFromSsdpMessage(response);
 
                 if (!devices.ContainsKey(device.Hostname))
                 {
@@ -397,7 +399,7 @@ namespace YeelightAPI
     /// </summary>
     /// <param name="ssdpMessage"></param>
     /// <returns></returns>
-    private static Device GetDeviceInformationsFromSsdpMessage(string ssdpMessage)
+    private static Device GetDeviceInformationFromSsdpMessage(string ssdpMessage)
     {
       if (ssdpMessage != null)
       {
@@ -473,7 +475,5 @@ namespace YeelightAPI
 
       return null;
     }
-
-    #endregion Private Methods
   }
 }

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -14,244 +15,421 @@ using YeelightAPI.Models;
 
 namespace YeelightAPI
 {
+  /// <summary>
+  ///   Finds devices through LAN
+  /// </summary>
+  public static class DeviceLocator
+  {
+    #region Private Fields
+
+    private const string _ssdpMessage =
+      "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1982\r\nMAN: \"ssdp:discover\"\r\nST: wifi_bulb";
+
+    private static readonly List<object> _allPropertyRealNames = PROPERTIES.ALL.GetRealNames();
+    private static readonly char[] _colon = {':'};
+    private static readonly IPEndPoint _multicastEndPoint = new IPEndPoint(IPAddress.Parse("239.255.255.250"), 1982);
+    private static readonly byte[] _ssdpDiagram = Encoding.ASCII.GetBytes(DeviceLocator._ssdpMessage);
+    private static readonly string _yeelightlocationMatch = "Location: yeelight://";
+
+    #endregion Private Fields
+
+    #region Depricated API. TODO: Remove
+
     /// <summary>
-    /// Finds devices through LAN
+    ///   Notification Received event
     /// </summary>
-    public static class DeviceLocator
+    [Obsolete("Deprecated. Event will be removed in next release.")]
+    public static event DeviceFoundEventHandler OnDeviceFound;
+
+    /// <summary>
+    ///   Notification Received event handler
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    [Obsolete("Deprecated. Event will be removed in next release.")]
+    public delegate void DeviceFoundEventHandler(object sender, DeviceFoundEventArgs e);
+
+    #region Public Methods
+
+    /// <summary>
+    ///   Discover devices in a specific Network Interface
+    /// </summary>
+    /// <param name="preferedInterface"></param>
+    /// <returns></returns>
+    [Obsolete("Deprecated. Use DiscoverAsync and overloads instead.")]
+    public static async Task<List<Device>> Discover(NetworkInterface preferedInterface)
     {
-        #region Private Fields
+      List<Task<List<Device>>> tasks = DeviceLocator.CreateDiscoverTasks(preferedInterface);
+      var devices = new List<Device>();
 
-        private const string _ssdpMessage = "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1982\r\nMAN: \"ssdp:discover\"\r\nST: wifi_bulb";
-        private static readonly List<object> _allPropertyRealNames = PROPERTIES.ALL.GetRealNames();
-        private static readonly char[] _colon = new char[] { ':' };
-        private static readonly IPEndPoint _multicastEndPoint = new IPEndPoint(IPAddress.Parse("239.255.255.250"), 1982);
-        private static readonly byte[] _ssdpDiagram = Encoding.ASCII.GetBytes(_ssdpMessage);
-        private static string _yeelightlocationMatch = "Location: yeelight://";
+      if (tasks.Count != 0)
+      {
+        await Task.WhenAll(tasks);
 
-        #endregion Private Fields
+        devices.AddRange(tasks.SelectMany(t => t.Result).GroupBy(d => d.Hostname).Select(g => g.First()));
+      }
 
-        /// <summary>
-        /// Notification Received event
-        /// </summary>
-        public static event DeviceFoundEventHandler OnDeviceFound;
-
-        /// <summary>
-        /// Notification Received event handler
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        public delegate void DeviceFoundEventHandler(object sender, DeviceFoundEventArgs e);
-
-        #region Public Methods
-
-        /// <summary>
-        /// Discover devices in a specific Network Interface
-        /// </summary>
-        /// <param name="preferedInterface"></param>
-        /// <returns></returns>
-        public static async Task<List<Device>> Discover(NetworkInterface preferedInterface)
-        {
-            List<Task<List<Device>>> tasks = CreateDiscoverTasks(preferedInterface);
-            List<Device> devices = new List<Device>();
-
-            if (tasks.Count != 0)
-            {
-                await Task.WhenAll(tasks);
-
-                devices.AddRange(tasks.SelectMany(t => t.Result).GroupBy(d => d.Hostname).Select(g => g.First()));
-            }
-
-            return devices;
-        }
-
-        /// <summary>
-        /// Discover devices in LAN
-        /// </summary>
-        /// <returns></returns>
-        public static async Task<List<Device>> Discover()
-        {
-            List<Task<List<Device>>> tasks = new List<Task<List<Device>>>();
-            List<Device> devices = new List<Device>();
-
-            foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces().Where(n => n.OperationalStatus == OperationalStatus.Up))
-            {
-                tasks.AddRange(CreateDiscoverTasks(ni));
-            }
-
-            if (tasks.Count != 0)
-            {
-                await Task.WhenAll(tasks);
-
-                devices.AddRange(tasks.SelectMany(t => t.Result).GroupBy(d => d.Hostname).Select(g => g.First()));
-            }
-
-            return devices;
-        }
-
-        #endregion Public Methods
-
-        #region Private Methods
-
-        /// <summary>
-        /// Create Discovery tasks for a specific Network Interface
-        /// </summary>
-        /// <param name="netInterface"></param>
-        /// <returns></returns>
-        private static List<Task<List<Device>>> CreateDiscoverTasks(NetworkInterface netInterface)
-        {
-            var devices = new ConcurrentDictionary<string, Device>();
-            List<Task<List<Device>>> tasks = new List<Task<List<Device>>>();
-
-            try
-            {
-                GatewayIPAddressInformation addr = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
-
-                if (addr != null && !addr.Address.ToString().Equals("0.0.0.0"))
-                {
-                    if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 || netInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
-                    {
-                        foreach (UnicastIPAddressInformation ip in netInterface.GetIPProperties().UnicastAddresses)
-                        {
-                            if (ip.Address.AddressFamily == AddressFamily.InterNetwork)
-                            {
-                                for (int cpt = 0; cpt < 3; cpt++)
-                                {
-                                    Task<List<Device>> t = Task.Factory.StartNew<List<Device>>(() =>
-                                    {
-                                        Socket ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
-                                        {
-                                            Blocking = false,
-                                            Ttl = 1,
-                                            UseOnlyOverlappedIO = true,
-                                            MulticastLoopback = false,
-                                        };
-                                        ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
-                                        ssdpSocket.SetSocketOption(
-                                            SocketOptionLevel.IP,
-                                            SocketOptionName.AddMembership,
-                                            new MulticastOption(_multicastEndPoint.Address));
-
-                                        ssdpSocket.SendTo(_ssdpDiagram, SocketFlags.None, _multicastEndPoint);
-
-                                        DateTime start = DateTime.Now;
-                                        while (DateTime.Now - start < TimeSpan.FromSeconds(1))
-                                        {
-                                            int available = ssdpSocket.Available;
-
-                                            if (available > 0)
-                                            {
-                                                byte[] buffer = new byte[available];
-                                                int i = ssdpSocket.Receive(buffer, SocketFlags.None);
-
-                                                if (i > 0)
-                                                {
-                                                    string response = Encoding.UTF8.GetString(buffer.Take(i).ToArray());
-                                                    Device device = GetDeviceInformationsFromSsdpMessage(response);
-
-                                                    //add only if no device already matching
-                                                    if(devices.TryAdd(device.Hostname, device))
-                                                    {
-                                                        OnDeviceFound?.Invoke(null, new DeviceFoundEventArgs(device));
-                                                    }
-                                                }
-                                            }
-                                            Thread.Sleep(10);
-                                        }
-
-                                        return devices.Values.ToList();
-                                    });
-                                    tasks.Add(t);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            catch { }
-
-            return tasks;
-        }
-
-        /// <summary>
-        /// Gets the informations from a raw SSDP message (host, port)
-        /// </summary>
-        /// <param name="ssdpMessage"></param>
-        /// <returns></returns>
-        private static Device GetDeviceInformationsFromSsdpMessage(string ssdpMessage)
-        {
-            if (ssdpMessage != null)
-            {
-                string[] split = ssdpMessage.Split(new string[] { Constants.LineSeparator }, StringSplitOptions.RemoveEmptyEntries);
-                string host = null;
-                int port = Constants.DefaultPort;
-                Dictionary<string, object> properties = new Dictionary<string, object>();
-                List<METHODS> supportedMethods = new List<METHODS>();
-                string id = null, firmwareVersion = null;
-                MODEL model = default(MODEL);
-
-                foreach (string part in split)
-                {
-                    if (part.StartsWith(_yeelightlocationMatch))
-                    {
-                        string url = part.Substring(_yeelightlocationMatch.Length);
-                        string[] hostnameParts = url.Split(_colon, StringSplitOptions.RemoveEmptyEntries);
-                        if (hostnameParts.Length >= 1)
-                        {
-                            host = hostnameParts[0];
-                        }
-                        if (hostnameParts.Length == 2)
-                        {
-                            int.TryParse(hostnameParts[1], out port);
-                        }
-                    }
-                    else
-                    {
-                        string[] property = part.Split(_colon);
-                        if (property.Length == 2)
-                        {
-                            string propertyName = property[0].Trim();
-                            string propertyValue = property[1].Trim();
-
-                            if (_allPropertyRealNames.Contains(propertyName))
-                            {
-                                properties.Add(propertyName, propertyValue);
-                            }
-                            else if (propertyName == "id")
-                            {
-                                id = propertyValue;
-                            }
-                            else if (propertyName == "model")
-                            {
-                                if (!RealNameAttributeExtension.TryParseByRealName(propertyValue, out model))
-                                {
-                                    model = default(MODEL);
-                                }
-                            }
-                            else if (propertyName == "support")
-                            {
-                                string[] supportedOperations = propertyValue.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-
-                                foreach (string operation in supportedOperations)
-                                {
-                                    if (RealNameAttributeExtension.TryParseByRealName(operation, out METHODS method))
-                                    {
-                                        supportedMethods.Add(method);
-                                    }
-                                }
-                            }
-                            else if (propertyName == "fw_ver")
-                            {
-                                firmwareVersion = propertyValue;
-                            }
-                        }
-                    }
-                }
-                return new Device(host, port, id, model, firmwareVersion, properties, supportedMethods);
-            }
-
-            return null;
-        }
-
-        #endregion Private Methods
+      return devices;
     }
+
+    /// <summary>
+    ///   Discover devices in LAN
+    /// </summary>
+    /// <returns></returns>
+    [Obsolete("Deprecated. Use DiscoverAsync and overloads instead.")]
+    public static async Task<List<Device>> Discover()
+    {
+      var tasks = new List<Task<List<Device>>>();
+      var devices = new List<Device>();
+
+      foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces()
+        .Where(n => n.OperationalStatus == OperationalStatus.Up))
+      {
+        tasks.AddRange(DeviceLocator.CreateDiscoverTasks(ni));
+      }
+
+      if (tasks.Count != 0)
+      {
+        await Task.WhenAll(tasks);
+
+        devices.AddRange(tasks.SelectMany(t => t.Result).GroupBy(d => d.Hostname).Select(g => g.First()));
+      }
+
+      return devices;
+    }
+
+    #endregion Public Methods
+
+    #region Private Methods
+
+    /// <summary>
+    ///   Create Discovery tasks for a specific Network Interface
+    /// </summary>
+    /// <param name="netInterface"></param>
+    /// <returns></returns>
+    [Obsolete("Deprecated. Use SearchNetworkForDevicesAsync instead")]
+    private static List<Task<List<Device>>> CreateDiscoverTasks(NetworkInterface netInterface)
+    {
+      var devices = new ConcurrentDictionary<string, Device>();
+      var tasks = new List<Task<List<Device>>>();
+
+     
+        GatewayIPAddressInformation addr = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
+
+        if (addr != null && !addr.Address.ToString().Equals("0.0.0.0"))
+        {
+          if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 ||
+              netInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+          {
+            foreach (UnicastIPAddressInformation ip in netInterface.GetIPProperties().UnicastAddresses)
+            {
+              if (ip.Address.AddressFamily == AddressFamily.InterNetwork)
+              {
+                for (var cpt = 0; cpt < 3; cpt++)
+                {
+                  Task<List<Device>> t = Task.Run(
+                    async () =>
+                    {
+                      try
+                      {
+                        using (var ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+                        {
+                          Blocking = false,
+                          Ttl = 1,
+                          UseOnlyOverlappedIO = true,
+                          MulticastLoopback = false
+                        })
+                        {
+                          ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
+                          ssdpSocket.SetSocketOption(
+                            SocketOptionLevel.IP,
+                            SocketOptionName.AddMembership,
+                            new MulticastOption(DeviceLocator._multicastEndPoint.Address));
+
+                          ssdpSocket.SendTo(
+                            DeviceLocator._ssdpDiagram,
+                            SocketFlags.None,
+                            DeviceLocator._multicastEndPoint);
+
+                          var stopWatch = new Stopwatch();
+                          stopWatch.Start();
+                          while (stopWatch.Elapsed < TimeSpan.FromSeconds(1))
+                          {
+                            try
+                            {
+                              int available = ssdpSocket.Available;
+
+                              if (available > 0)
+                              {
+                                var buffer = new byte[available];
+                                int i = ssdpSocket.Receive(buffer, SocketFlags.None);
+
+                                if (i > 0)
+                                {
+                                  string response = Encoding.UTF8.GetString(buffer.Take(i).ToArray());
+                                  Device device = DeviceLocator.GetDeviceInformationsFromSsdpMessage(response);
+
+                                  //add only if no device already matching
+                                  if (devices.TryAdd(device.Hostname, device))
+                                  {
+                                    DeviceLocator.OnDeviceFound?.Invoke(null, new DeviceFoundEventArgs(device));
+                                  }
+                                }
+                              }
+                            }
+                            catch (SocketException)
+                            {
+                            }
+
+                            await Task.Delay(TimeSpan.FromMilliseconds(10));
+                          }
+                        }
+                      }
+                      catch (SocketException)
+                      {
+                      }
+
+                      return devices.Values.ToList();
+                    });
+
+                  tasks.Add(t);
+                }
+              }
+            }
+          }
+        }
+
+      return tasks;
+    }
+
+    #endregion Depricated API. TODO: Remove
+
+
+    #region Public Methods
+
+    /// <summary>
+    ///   Discover devices in LAN
+    /// </summary>
+    /// <returns></returns>
+    public static async Task<IEnumerable<Device>> DiscoverAsync() =>
+      await DeviceLocator.DiscoverAsync(deviceFoundReporter: null);
+
+    /// <summary>
+    ///   Discover devices in LAN
+    /// </summary>
+    /// <returns></returns>
+    public static async Task<IEnumerable<Device>> DiscoverAsync(IProgress<Device> deviceFoundReporter)
+    {
+      var devices = new List<Device>();
+
+      foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces()
+        .Where(n => n.OperationalStatus == OperationalStatus.Up))
+      {
+        devices.AddRange(await DeviceLocator.DiscoverAsync(ni, deviceFoundReporter));
+      }
+
+      return devices;
+    }
+
+    /// <summary>
+    ///   Discover devices in a specific Network Interface
+    /// </summary>
+    /// <param name="networkInterface"></param>
+    /// <returns></returns>
+    public static async Task<IEnumerable<Device>> DiscoverAsync(NetworkInterface networkInterface) =>
+      await DeviceLocator.DiscoverAsync(networkInterface, null);
+
+    /// <summary>
+    ///   Discover devices in a specific Network Interface
+    /// </summary>
+    /// <param name="networkInterface"></param>
+    /// <param name="deviceFoundReporter"></param>
+    /// <returns></returns>
+    public static async Task<IEnumerable<Device>> DiscoverAsync(
+      NetworkInterface networkInterface,
+      IProgress<Device> deviceFoundReporter) =>
+      await DeviceLocator.SearchNetworkForDevicesAsync(networkInterface, deviceFoundReporter);
+
+    #endregion Public Methods
+
+    /// <summary>
+    ///   Create Discovery tasks for a specific Network Interface
+    /// </summary>
+    /// <param name="netInterface"></param>
+    /// <param name="deviceFoundCallback"></param>
+    /// <returns></returns>
+    private static async Task<IEnumerable<Device>> SearchNetworkForDevicesAsync(NetworkInterface netInterface, IProgress<Device> deviceFoundCallback)
+    {
+      GatewayIPAddressInformation addressInformation = netInterface.GetIPProperties().GatewayAddresses.FirstOrDefault();
+
+      if (addressInformation == null || addressInformation.Address.ToString().Equals("0.0.0.0"))
+      {
+        return new List<Device>();
+      }
+
+      if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 ||
+          netInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+      {
+        return await Task.Run(
+          () => netInterface.GetIPProperties().UnicastAddresses
+            .Where(ip => ip.Address.AddressFamily == AddressFamily.InterNetwork)
+            .AsParallel()
+            .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
+            .SelectMany(ip => DeviceLocator.CheckSocketForDevices(ip, deviceFoundCallback))
+            .ToList());
+      }
+
+      return new List<Device>();
+    }
+
+    private static List<Device> CheckSocketForDevices(UnicastIPAddressInformation ip, IProgress<Device> deviceFoundCallback)
+    {
+      // Use hash table for faster lookup, than List.Contains
+      var devices = new Dictionary<string, Device>();
+
+      try // Catch socket creation exception
+      {
+        using (var ssdpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+        {
+          Blocking = false,
+          Ttl = 1,
+          UseOnlyOverlappedIO = true,
+          MulticastLoopback = false
+        })
+        {
+          ssdpSocket.Bind(new IPEndPoint(ip.Address, 0));
+          ssdpSocket.SetSocketOption(
+            SocketOptionLevel.IP,
+            SocketOptionName.AddMembership,
+            new MulticastOption(DeviceLocator._multicastEndPoint.Address));
+
+          ssdpSocket.SendTo(DeviceLocator._ssdpDiagram, SocketFlags.None, DeviceLocator._multicastEndPoint);
+
+          var stopWatch = new Stopwatch();
+          stopWatch.Start();
+          while (stopWatch.Elapsed < TimeSpan.FromSeconds(1))
+          {
+            try // Catch socket read exception
+            {
+              int available = ssdpSocket.Available;
+
+              if (available > 0)
+              {
+                var buffer = new byte[available];
+                int numberOfBytesRead = ssdpSocket.Receive(buffer, SocketFlags.None);
+
+                if (numberOfBytesRead > 0)
+                {
+                  string response = Encoding.UTF8.GetString(buffer.Take(numberOfBytesRead).ToArray());
+                  Device device = DeviceLocator.GetDeviceInformationsFromSsdpMessage(response);
+
+                  if (!devices.ContainsKey(device.Hostname))
+                  {
+                    devices.Add(device.Hostname, device);
+                    deviceFoundCallback?.Report(device);
+                  }
+                }
+              }
+            }
+            catch (SocketException)
+            {
+              // Ignore and continue
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(10));
+          }
+        }
+      }
+      catch (SocketException)
+      {
+        return new List<Device>();
+      }
+
+      return devices.Values.ToList();
+    }
+
+    /// <summary>
+    ///   Gets the informations from a raw SSDP message (host, port)
+    /// </summary>
+    /// <param name="ssdpMessage"></param>
+    /// <returns></returns>
+    private static Device GetDeviceInformationsFromSsdpMessage(string ssdpMessage)
+    {
+      if (ssdpMessage != null)
+      {
+        string[] split = ssdpMessage.Split(new[] {Constants.LineSeparator}, StringSplitOptions.RemoveEmptyEntries);
+        string host = null;
+        int port = Constants.DefaultPort;
+        var properties = new Dictionary<string, object>();
+        var supportedMethods = new List<METHODS>();
+        string id = null, firmwareVersion = null;
+        MODEL model = default;
+
+        foreach (string part in split)
+        {
+          if (part.StartsWith(DeviceLocator._yeelightlocationMatch))
+          {
+            string url = part.Substring(DeviceLocator._yeelightlocationMatch.Length);
+            string[] hostnameParts = url.Split(DeviceLocator._colon, StringSplitOptions.RemoveEmptyEntries);
+            if (hostnameParts.Length >= 1)
+            {
+              host = hostnameParts[0];
+            }
+
+            if (hostnameParts.Length == 2)
+            {
+              int.TryParse(hostnameParts[1], out port);
+            }
+          }
+          else
+          {
+            string[] property = part.Split(DeviceLocator._colon);
+            if (property.Length == 2)
+            {
+              string propertyName = property[0].Trim();
+              string propertyValue = property[1].Trim();
+
+              if (DeviceLocator._allPropertyRealNames.Contains(propertyName))
+              {
+                properties.Add(propertyName, propertyValue);
+              }
+              else if (propertyName == "id")
+              {
+                id = propertyValue;
+              }
+              else if (propertyName == "model")
+              {
+                if (!RealNameAttributeExtension.TryParseByRealName(propertyValue, out model))
+                {
+                  model = default;
+                }
+              }
+              else if (propertyName == "support")
+              {
+                string[] supportedOperations = propertyValue.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (string operation in supportedOperations)
+                {
+                  if (RealNameAttributeExtension.TryParseByRealName(operation, out METHODS method))
+                  {
+                    supportedMethods.Add(method);
+                  }
+                }
+              }
+              else if (propertyName == "fw_ver")
+              {
+                firmwareVersion = propertyValue;
+              }
+            }
+          }
+        }
+
+        return new Device(host, port, id, model, firmwareVersion, properties, supportedMethods);
+      }
+
+      return null;
+    }
+
+    #endregion Private Methods
+  }
 }

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -207,15 +207,17 @@ namespace YeelightAPI
     /// <returns></returns>
     public static async Task<IEnumerable<Device>> DiscoverAsync(IProgress<Device> deviceFoundReporter)
     {
-      var devices = new List<Device>();
+      var tasks = new List<Task<IEnumerable<Device>>>();
 
       foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces()
         .Where(n => n.OperationalStatus == OperationalStatus.Up))
       {
-        devices.AddRange(await DeviceLocator.DiscoverAsync(ni, deviceFoundReporter));
+        tasks.Add(DeviceLocator.DiscoverAsync(ni, deviceFoundReporter));
       }
 
-      return devices;
+
+      IEnumerable<Device>[] result = await Task.WhenAll(tasks);
+      return result.SelectMany(devices => devices).ToList();
     }
 
     /// <summary>

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -79,7 +79,11 @@ namespace YeelightAPI
       List<Task<List<Device>>> tasks = DeviceLocator.CreateDiscoverTasks(preferedInterface);
 
       List<Device>[] result = await Task.WhenAll(tasks);
-      return result.SelectMany(devices => devices).ToList();
+      return result
+        .SelectMany(devices => devices)
+        .GroupBy(d => d.Hostname)
+        .Select(g => g.First())
+        .ToList();
     }
 
     /// <summary>
@@ -99,7 +103,11 @@ namespace YeelightAPI
 
 
       List<Device>[] result = await Task.WhenAll(tasks);
-      return result.SelectMany(devices => devices).ToList();
+      return result
+        .SelectMany(devices => devices)
+        .GroupBy(d => d.Hostname)
+        .Select(g => g.First())
+        .ToList();
     }
 
     #endregion Public Methods
@@ -163,7 +171,7 @@ namespace YeelightAPI
                     SocketFlags.None,
                     DeviceLocator._multicastEndPoint);
 
-                  stopWatch.Restart();
+                  stopWatch.Start();
                   while (stopWatch.Elapsed < TimeSpan.FromSeconds(1))
                   {
                     try
@@ -239,7 +247,11 @@ namespace YeelightAPI
         .Select(networkInterface => DeviceLocator.DiscoverAsync(networkInterface, deviceFoundReporter));
 
       IEnumerable<Device>[] result = await Task.WhenAll(tasks);
-      return result.SelectMany(devices => devices).ToList();
+      return result
+        .SelectMany(devices => devices)
+        .GroupBy(d => d.Hostname)
+        .Select(g => g.First())
+        .ToList();
     }
 
     /// <summary>

--- a/YeelightAPI/DeviceLocator.cs
+++ b/YeelightAPI/DeviceLocator.cs
@@ -60,16 +60,9 @@ namespace YeelightAPI
     public static async Task<List<Device>> Discover(NetworkInterface preferedInterface)
     {
       List<Task<List<Device>>> tasks = DeviceLocator.CreateDiscoverTasks(preferedInterface);
-      var devices = new List<Device>();
 
-      if (tasks.Count != 0)
-      {
-        await Task.WhenAll(tasks);
-
-        devices.AddRange(tasks.SelectMany(t => t.Result).GroupBy(d => d.Hostname).Select(g => g.First()));
-      }
-
-      return devices;
+      List<Device>[] result = await Task.WhenAll(tasks);
+      return result.SelectMany(devices => devices).ToList();
     }
 
     /// <summary>
@@ -80,7 +73,6 @@ namespace YeelightAPI
     public static async Task<List<Device>> Discover()
     {
       var tasks = new List<Task<List<Device>>>();
-      var devices = new List<Device>();
 
       foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces()
         .Where(n => n.OperationalStatus == OperationalStatus.Up))
@@ -88,14 +80,9 @@ namespace YeelightAPI
         tasks.AddRange(DeviceLocator.CreateDiscoverTasks(ni));
       }
 
-      if (tasks.Count != 0)
-      {
-        await Task.WhenAll(tasks);
 
-        devices.AddRange(tasks.SelectMany(t => t.Result).GroupBy(d => d.Hostname).Select(g => g.First()));
-      }
-
-      return devices;
+      List<Device>[] result = await Task.WhenAll(tasks);
+      return result.SelectMany(devices => devices).ToList();
     }
 
     #endregion Public Methods


### PR DESCRIPTION
- Mark current event API of `DeviceLocator ` as obsolete
- Create region for obsolete code
- Fix current API exception handling in `DeviceLocator`
- Fix wrong usages of `Task.WhenAll` (removed possible deadlock)
- Dispose `Socket`
- Rename public API members (append suffix _Async_)
- Re-implement public API members
- Add API overloads to accept `IProgress<T>`
- Add `RetryCount` property to public API
- Refactor existing code to use Parallel LINQ to simplify code
- Use `Stopwatch ` to check elapsed time, instead of `DateTime`, for more readability
- Update usage examples in  _README.md_ to meet the new API changes of `DeviceLocator`
- Normalize formatting of _README.md_