### PR TITLE
Fix correct disposing of Device with a single question mark

### DIFF
--- a/YeelightAPI/Device.IDeviceController.cs
+++ b/YeelightAPI/Device.IDeviceController.cs
@@ -157,7 +157,7 @@ namespace YeelightAPI
                 _tcpClient = null;
                 try
                 {
-                    _watchCancellationTokenSource.Cancel();
+                    _watchCancellationTokenSource?.Cancel();
                 }
                 catch (ObjectDisposedException) { }
             }


### PR DESCRIPTION
**Describe the bug**
```csharp
using (YeelightAPI.Device device = new YeelightAPI.Device(ip, port))
{
    await device.Connect();
    await function(device);
}
```
When this code tries to connect to a lamp, which is not turned on, it will throw a `System.Net.Internals.SocketExceptionFactory+ExtendedSocketException (113)` with message `No route to host YOURIP:YOURPORT`. This in turn will propogate upward.

As I'm using a `using` statement, it will call Dispose in this fashion:
```
   at YeelightAPI.Device.Disconnect()
   at YeelightAPI.Device.Dispose(Boolean disposing)
   at YeelightAPI.Device.Dispose()
```

In the Disconnect method, [this line](https://github.com/roddone/YeelightAPI/blob/8b8874a8380c5a60925ca28a838e75297783e13c/YeelightAPI/Device.IDeviceController.cs#L160) exists:
```csharp
_watchCancellationTokenSource.Cancel();
```

However, since, we never initiated this object, it will throw a `NullReferenceException`.

**Expected behavior**
A `SocketException`

**Actual behaviour**
A `NullReferenceException`

**Fix**
One question mark