### PR TITLE
Don't set MusicMode enabled before the set_music command succeeds

### DIFF
--- a/YeelightAPI/Device.IDeviceController.cs
+++ b/YeelightAPI/Device.IDeviceController.cs
@@ -342,7 +342,6 @@ namespace YeelightAPI
         /// <returns></returns>
         public async Task<bool> StartMusicMode(string hostname = null, int port = 12345)
         {
-            this.IsMusicModeEnabled = true;
             //init new TCP socket
             if (string.IsNullOrWhiteSpace(hostname))
             {
@@ -360,6 +359,7 @@ namespace YeelightAPI
 
             if (result.IsOk())
             {
+                this.IsMusicModeEnabled = true;
                 this.Disconnect();
                 var musicTcpClient = await listener.AcceptTcpClientAsync();
                 _tcpClient = musicTcpClient;


### PR DESCRIPTION
I had a few issues with the StartMusicMode command, which turned out to be caused by my device apparently not supporting music mode at all (ie. the `music_on` property returns an empty value instead of a valid int). I observed that the `set_music` command returned `{"code": -1, "message": "method not supported"}`, but that this was swallowed by YeelightAPI, because `this.IsMusicModeEnabled` was already `true`.
